### PR TITLE
fix: configure Yarn nodeLinker to use node-modules instead of PnP

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
Closes #3

## What
Added .yarnrc.yml with nodeLinker: node-modules to force Yarn 
to generate a standard node_modules folder instead of using PnP.

## Why
Yarn 4 defaults to PnP mode which generates .pnp.cjs and 
.pnp.loader.mjs instead of node_modules. This prevents VS Code 
and NestJS from resolving dependencies correctly.

## Changes
- Add .yarnrc.yml
- Delete .pnp.cjs and .pnp.loader.mjs
- Update .gitignore