### PR TITLE
fix(ci): enable Corepack and enforce status checks on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "yarn"
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -42,14 +42,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "yarn"
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           node-version: 20
           cache: "yarn"
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
@@ -44,6 +47,9 @@ jobs:
         with:
           node-version: 20
           cache: "yarn"
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -2,8 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { AiService, GeneratedTicket } from './ai.service';
 
-const mockGenerateContent = jest.fn();
-
+const mockGenerateContent = jest.fn() as jest.MockedFunction<
+  (prompt: string) => Promise<{ response: { text: () => string } }>
+>;
 jest.mock('@google/generative-ai', () => ({
   GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
     getGenerativeModel: jest.fn().mockReturnValue({
@@ -72,7 +73,7 @@ describe('AiService', () => {
 
     it('should include the customer request inside the prompt sent to Gemini', async () => {
       await service.generateTicket(CUSTOMER_REQUEST);
-      const prompt = mockGenerateContent.mock.calls[0][0] as string;
+      const prompt = mockGenerateContent.mock.calls[0][0];
       expect(prompt).toContain(CUSTOMER_REQUEST);
     });
 

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { GenerativeModel, GoogleGenerativeAI } from '@google/generative-ai';
 import { buildTicketPrompt } from './ai.prompts';
 
 export interface GeneratedTicket {
@@ -13,7 +13,7 @@ export interface GeneratedTicket {
 
 @Injectable()
 export class AiService {
-  private model;
+  private model: GenerativeModel;
 
   constructor(private config: ConfigService) {
     const apiKey = this.config.get<string>('GEMINI_API_KEY');

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -16,4 +16,4 @@ async function bootstrap() {
 
   await app.listen(3000);
 }
-bootstrap();
+bootstrap().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "dev": "concurrently \"yarn dev:backend\" \"yarn dev:frontend\"",
     "build:frontend": "yarn workspace frontend build",
     "build:backend": "yarn workspace backend build",
-    "lint": "yarn workspaces foreach run lint",
-    "test": "yarn workspaces foreach run test"
+    "build": "concurrently \"yarn build:backend\" \"yarn build:frontend\"",
+    "lint": "yarn workspaces foreach --all run lint",
+    "test": "yarn workspaces foreach --all run test"
   },
   "devDependencies": {
     "concurrently": "^9.2.1"


### PR DESCRIPTION
## What
Fix CI pipeline and enforce status checks on branch protection rules 
to prevent merging PRs with failing checks.

## Changes

### CI
- Add corepack enable step to both backend and frontend jobs
  to ensure Yarn 4.12.0 is used instead of the system default (1.22.22)

### Branch protection
- Added required status checks to the main branch ruleset:
  - Backend — Lint, Test, Build
  - Frontend — Lint, Build
- Enabled "Require branches to be up to date before merging"

## Notes
- The previous PR was merged despite failing checks because the 
  status checks were not yet enforced in the ruleset. This fix 
  prevents it from happening again.

Closes #11