### PR TITLE
feat: frontend add demo mode with mocked data

### DIFF
--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -3,13 +3,13 @@ import { ConfigService } from '@nestjs/config';
 import { GenerativeModel, GoogleGenerativeAI } from '@google/generative-ai';
 import { buildTicketPrompt } from './ai.prompts';
 
-export interface GeneratedTicket {
+export type GeneratedTicket = {
   title: string;
   description: string;
   priority: 'low' | 'medium' | 'high';
   estimatedDays: number;
   tags: string[];
-}
+};
 
 @Injectable()
 export class AiService {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,10 +6,10 @@ import { JwtPayload } from './jwt.strategy';
 import { User } from '../users/user.entity';
 import { LoginDto } from './dto/login.dto';
 
-export interface LoginResponse {
+export type LoginResponse = {
   accessToken: string;
   user: Pick<User, 'id' | 'email' | 'role'>;
-}
+};
 
 @Injectable()
 export class AuthService {

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -5,17 +5,17 @@ import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 import { Role } from '../users/user.entity';
 
-export interface JwtPayload {
+export type JwtPayload = {
   sub: string;
   email: string;
   role: Role;
-}
+};
 
-export interface JwtUser {
+export type JwtUser = {
   id: string;
   email: string;
   role: Role;
-}
+};
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,8 @@
-VITE_THEME=         # 'light' | 'dark' | leave empty to use OS theme
-# VITE_API_URL -> If not set default to localhost:3000
+#Theme
+VITE_THEME= # 'light' | 'dark' | leave empty to use OS theme
+
+# API
+# VITE_API_URL -> If not set default to localhost:3000 or backend:3000 on docker
+
+# Demo
+VITE_DEMO_MODE=false

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,14 +1,14 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(["dist", "public/mockServiceWorker.js"]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
@@ -20,4 +20,4 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
-])
+]);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.13.6",
     "i18next": "^25.8.18",
     "i18next-browser-languagedetector": "^8.2.1",
+    "msw": "^2.12.14",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-i18next": "^16.5.8",
@@ -36,5 +37,10 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
     "vite": "^8.0.0"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.12.14'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,11 +5,30 @@ import {
   Select,
   MenuItem,
   type SelectChangeEvent,
+  Stack,
+  Tooltip,
+  Chip,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
+const isDemoMode = import.meta.env.VITE_DEMO_MODE === "true";
+
+const SUPPORTED_LANGUAGES = [
+  { code: "en", label: "English", flag: "🇬🇧" },
+  { code: "it", label: "Italiano", flag: "🇮🇹" },
+] as const;
+
+type LanguageCode = (typeof SUPPORTED_LANGUAGES)[number]["code"];
+
+function resolveLanguageCode(lng: string): LanguageCode {
+  const match = SUPPORTED_LANGUAGES.find(({ code }) => lng.startsWith(code));
+  return match?.code ?? SUPPORTED_LANGUAGES[0].code;
+}
+
 export default function Header() {
-  const { i18n } = useTranslation("common");
+  const { i18n, t } = useTranslation("common");
+
+  const currentLanguage = resolveLanguageCode(i18n.language);
 
   const handleLanguageChange = (event: SelectChangeEvent) => {
     i18n.changeLanguage(event.target.value);
@@ -18,17 +37,35 @@ export default function Header() {
   return (
     <AppBar position="static" color="default" elevation={1}>
       <Toolbar sx={{ justifyContent: "space-between" }}>
-        <Typography variant="h6" fontWeight="bold">
-          TeamFlow
-        </Typography>
-        <Select
-          value={i18n.language.startsWith("it") ? "it" : "en"}
+        <Stack direction="row" spacing={1}>
+          <Typography variant="h6" fontWeight="bold">
+            TeamFlow
+          </Typography>
+          {isDemoMode && (
+            <Tooltip title={t("demoMode")}>
+              <Chip label={t("demo")} variant="outlined" />
+            </Tooltip>
+          )}
+        </Stack>
+        <Select<LanguageCode>
+          value={currentLanguage}
           onChange={handleLanguageChange}
           size="small"
           variant="outlined"
+          renderValue={(code) => {
+            const lang = SUPPORTED_LANGUAGES.find((l) => l.code === code);
+            return lang?.flag;
+          }}
+          sx={{
+            "& fieldset": { top: 0 }, // Remove notch offset
+            "& fieldset legend": { display: "none" }, // Remove legend
+          }}
         >
-          <MenuItem value="en">🇬🇧 English</MenuItem>
-          <MenuItem value="it">🇮🇹 Italiano</MenuItem>
+          {SUPPORTED_LANGUAGES.map(({ code, label, flag }) => (
+            <MenuItem key={code} value={code}>
+              {flag} {label}
+            </MenuItem>
+          ))}
         </Select>
       </Toolbar>
     </AppBar>

--- a/frontend/src/components/TicketCard.tsx
+++ b/frontend/src/components/TicketCard.tsx
@@ -15,11 +15,11 @@ const priorityColor = {
   high: "error",
 } as const;
 
-interface Props {
+type GeneratedTicketProps = {
   ticket: GeneratedTicket;
-}
+};
 
-export default function TicketCard({ ticket }: Props) {
+export default function TicketCard({ ticket }: GeneratedTicketProps) {
   const { t } = useTranslation("generateTicket");
 
   return (

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -5,6 +5,7 @@
     "password": "Password",
     "submit": "Sign in",
     "submitting": "Signing in...",
-    "error": "Invalid email or password"
+    "error": "Invalid email or password",
+    "demoCredentials": "Demo credentials are pre-filled. Just click Sign in."
   }
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,5 +1,7 @@
 {
   "error": "Something went wrong. Please try again.",
   "reset": "Reset",
-  "language": "Language"
+  "language": "Language",
+  "demoMode": "Demo mode — running without backend. Data is mocked.",
+  "demo": "Demo"
 }

--- a/frontend/src/i18n/locales/en/generateTicket.json
+++ b/frontend/src/i18n/locales/en/generateTicket.json
@@ -8,5 +8,6 @@
   "result": "Generated ticket",
   "estimatedDays_one": "{{count}} day",
   "estimatedDays_other": "{{count}} days",
-  "estimatedEffort": "Estimated effort"
+  "estimatedEffort": "Estimated effort",
+  "demoMode": "Demo mode — running without backend. Ticket data is mocked, regardless of what is written in the input text."
 }

--- a/frontend/src/i18n/locales/it/auth.json
+++ b/frontend/src/i18n/locales/it/auth.json
@@ -5,6 +5,7 @@
     "password": "Password",
     "submit": "Accedi",
     "submitting": "Accesso in corso...",
-    "error": "Email o password non validi"
+    "error": "Email o password non validi",
+    "demoCredentials": "Le credenziali demo sono già inserite. Clicca su Accedi."
   }
 }

--- a/frontend/src/i18n/locales/it/common.json
+++ b/frontend/src/i18n/locales/it/common.json
@@ -1,5 +1,7 @@
 {
   "error": "Qualcosa è andato storto. Riprova.",
   "reset": "Reset",
-  "language": "Lingua"
+  "language": "Lingua",
+  "demoMode": "Modalità demo — il backend non è attivo. I dati sono simulati.",
+  "demo": "Demo"
 }

--- a/frontend/src/i18n/locales/it/generateTicket.json
+++ b/frontend/src/i18n/locales/it/generateTicket.json
@@ -8,5 +8,6 @@
   "result": "Ticket generato",
   "estimatedDays_one": "{{count}} giorno",
   "estimatedDays_other": "{{count}} giorni",
-  "estimatedEffort": "Stima"
+  "estimatedEffort": "Stima",
+  "demoMode": "Modalità demo — il backend non è attivo. I dati sono simulati, indipendetemente da cosa verrà scritto nell'input di testo"
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,14 +7,25 @@ import { BrowserRouter } from "react-router-dom";
 
 const queryClient = new QueryClient();
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </QueryClientProvider>
-    </BrowserRouter>
-  </StrictMode>,
-);
+async function bootstrap() {
+  if (import.meta.env.VITE_DEMO_MODE === "true") {
+    const { worker } = await import("./mocks/browser");
+    await worker.start({
+      onUnhandledRequest: "bypass",
+    });
+  }
+
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </QueryClientProvider>
+      </BrowserRouter>
+    </StrictMode>,
+  );
+}
+
+bootstrap().catch(console.error);

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from "msw/browser";
+import { authHandlers } from "./handlers/auth.handlers";
+import { aiHandlers } from "./handlers/ai.handlers";
+
+export const worker = setupWorker(...authHandlers, ...aiHandlers);

--- a/frontend/src/mocks/data/ai.data.ts
+++ b/frontend/src/mocks/data/ai.data.ts
@@ -1,0 +1,12 @@
+import type { GeneratedTicket } from "../../types/generatedTicket";
+
+export const mockGeneratedTicket: GeneratedTicket = {
+  title: "Add PDF export button to reports page",
+  description:
+    "Implement a button on the reports page that allows users to export " +
+    "the current view as a PDF file. The export should include all visible " +
+    "data and respect the current filters applied by the user.",
+  priority: "medium",
+  estimatedDays: 3,
+  tags: ["export", "pdf", "reports", "frontend"],
+};

--- a/frontend/src/mocks/data/auth.data.ts
+++ b/frontend/src/mocks/data/auth.data.ts
@@ -1,0 +1,7 @@
+import type { AuthUser } from "../../types/authUser";
+
+export const mockAdminUser: AuthUser = {
+  id: "mock-uuid-admin",
+  email: "admin@teamflow.com",
+  role: "admin",
+};

--- a/frontend/src/mocks/handlers/ai.handlers.ts
+++ b/frontend/src/mocks/handlers/ai.handlers.ts
@@ -1,0 +1,9 @@
+import { http, HttpResponse, delay } from "msw";
+import { mockGeneratedTicket } from "../data/ai.data";
+
+export const aiHandlers = [
+  http.post("/api/ai/generate-ticket", async () => {
+    await delay(1500);
+    return HttpResponse.json(mockGeneratedTicket);
+  }),
+];

--- a/frontend/src/mocks/handlers/auth.handlers.ts
+++ b/frontend/src/mocks/handlers/auth.handlers.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse, delay } from "msw";
+import { mockAdminUser } from "../data/auth.data";
+
+export const authHandlers = [
+  http.post<never, { email: string; password: string }>(
+    "/api/auth/login",
+    async ({ request }) => {
+      await delay(800);
+      const { email, password } = await request.json();
+      if (email !== "admin@teamflow.com" || password !== "admin123")
+        return HttpResponse.json(
+          {
+            message: "Invalid credentials",
+            error: "Unauthorized",
+            statusCode: 401,
+          },
+          { status: 401 },
+        );
+      return HttpResponse.json({ user: mockAdminUser });
+    },
+  ),
+
+  http.post("/api/auth/logout", async () => {
+    await delay(300);
+    return HttpResponse.json({ success: true });
+  }),
+];

--- a/frontend/src/pages/GenerateTicketPage.tsx
+++ b/frontend/src/pages/GenerateTicketPage.tsx
@@ -15,6 +15,8 @@ import { generateTicket } from "../api/ai";
 import TicketCard from "../components/TicketCard";
 import type { GeneratedTicket } from "../types/generatedTicket";
 
+const isDemoMode = import.meta.env.VITE_DEMO_MODE === "true";
+
 export default function GenerateTicketPage() {
   const { t: tCommon } = useTranslation("common");
   const { t } = useTranslation("generateTicket");
@@ -32,8 +34,6 @@ export default function GenerateTicketPage() {
     setCustomerRequest("");
   };
 
-  console.log("Hi");
-
   return (
     <Container maxWidth="md">
       <Box sx={{ py: 6 }}>
@@ -44,6 +44,12 @@ export default function GenerateTicketPage() {
         <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
           {t("subtitle")}
         </Typography>
+
+        {isDemoMode && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            {t("demoMode")}
+          </Alert>
+        )}
 
         <TextField
           fullWidth

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -15,12 +15,14 @@ import {
 import { login } from "../api/auth";
 import { useAuth } from "../providers/useAuth";
 
+const isDemoMode = import.meta.env.VITE_DEMO_MODE === "true";
+
 export default function LoginPage() {
   const { t } = useTranslation("auth");
   const { setUser } = useAuth();
   const navigate = useNavigate();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [email, setEmail] = useState(isDemoMode ? "admin@teamflow.com" : "");
+  const [password, setPassword] = useState(isDemoMode ? "admin123" : "");
 
   const mutation = useMutation({
     mutationFn: () => login(email, password),
@@ -38,9 +40,9 @@ export default function LoginPage() {
             {t("login.title")}
           </Typography>
 
-          {mutation.isError && (
-            <Alert severity="error" sx={{ mb: 2 }}>
-              {t("login.error")}
+          {isDemoMode && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              {t("login.demoCredentials")}
             </Alert>
           )}
 
@@ -61,6 +63,12 @@ export default function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
             sx={{ mb: 3 }}
           />
+
+          {mutation.isError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {t("login.error")}
+            </Alert>
+          )}
 
           <Button
             fullWidth

--- a/frontend/src/providers/Auth.Context.ts
+++ b/frontend/src/providers/Auth.Context.ts
@@ -1,10 +1,10 @@
 import { createContext } from "react";
 import type { AuthUser } from "../types/authUser";
 
-export interface AuthContextType {
+export type AuthContextType = {
   user: AuthUser | null;
   setUser: (user: AuthUser | null) => void;
   isAuthenticated: boolean;
-}
+};
 
 export const AuthContext = createContext<AuthContextType | null>(null);

--- a/frontend/src/types/authUser.ts
+++ b/frontend/src/types/authUser.ts
@@ -1,5 +1,5 @@
-export interface AuthUser {
+export type AuthUser = {
   id: string;
   email: string;
   role: "admin" | "manager" | "employee";
-}
+};

--- a/frontend/src/types/generatedTicket.ts
+++ b/frontend/src/types/generatedTicket.ts
@@ -1,7 +1,7 @@
-export interface GeneratedTicket {
+export type GeneratedTicket = {
   title: string;
   description: string;
   priority: "low" | "medium" | "high";
   estimatedDays: number;
   tags: string[];
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,7 +866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/confirm@npm:^5.1.21, @inquirer/confirm@npm:^5.1.6":
+"@inquirer/confirm@npm:^5.0.0, @inquirer/confirm@npm:^5.1.21, @inquirer/confirm@npm:^5.1.6":
   version: 5.1.21
   resolution: "@inquirer/confirm@npm:5.1.21"
   dependencies:
@@ -1459,6 +1459,20 @@ __metadata:
   version: 0.16.0
   resolution: "@microsoft/tsdoc@npm:0.16.0"
   checksum: 10c0/8883bb0ed22753af7360e9222687fda4eb448f0a574ea34b4596c11e320148b3ae0d24e00f8923df8ba7bc62a46a6f53b9343243a348640d923dfd55d52cd6bb
+  languageName: node
+  linkType: hard
+
+"@mswjs/interceptors@npm:^0.41.2":
+  version: 0.41.3
+  resolution: "@mswjs/interceptors@npm:0.41.3"
+  dependencies:
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/logger": "npm:^0.3.0"
+    "@open-draft/until": "npm:^2.0.0"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    strict-event-emitter: "npm:^0.5.1"
+  checksum: 10c0/a259bbfc3bb4caada7a9a3529cc830159818e838c152df89ac890e7203df615a5e070ca63aa1e70a39868322ff5c1441ab74bbadb4081ca55b0c3a462e2903c0
   languageName: node
   linkType: hard
 
@@ -2108,6 +2122,30 @@ __metadata:
   bin:
     opencollective: bin/opencollective.js
   checksum: 10c0/ef2835d8635d2928152eff8b5a1ec42c145e2ab00cb02ff4bb61f0a6f5528afc9b169c06c32308c783779fe26855ebc67419743046caa80e582e814cff73187d
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@open-draft/deferred-promise@npm:2.2.0"
+  checksum: 10c0/eafc1b1d0fc8edb5e1c753c5e0f3293410b40dde2f92688211a54806d4136887051f39b98c1950370be258483deac9dfd17cf8b96557553765198ef2547e4549
+  languageName: node
+  linkType: hard
+
+"@open-draft/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@open-draft/logger@npm:0.3.0"
+  dependencies:
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.0"
+  checksum: 10c0/90010647b22e9693c16258f4f9adb034824d1771d3baa313057b9a37797f571181005bc50415a934eaf7c891d90ff71dcd7a9d5048b0b6bb438f31bef2c7c5c1
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "@open-draft/until@npm:2.1.0"
+  checksum: 10c0/61d3f99718dd86bb393fee2d7a785f961dcaf12f2055f0c693b27f4d0cd5f7a03d498a6d9289773b117590d794a43cd129366fd8e99222e4832f67b1653d54cf
   languageName: node
   linkType: hard
 
@@ -2951,6 +2989,13 @@ __metadata:
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 10c0/1f4658385ae936330581bcb8aa3a066df03867d90281cdf89cc356d404bd6579be0f11902304e1f775d92df22c6dd761d4451c804b0a4fba973e06211e9bd77c
+  languageName: node
+  linkType: hard
+
+"@types/statuses@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@types/statuses@npm:2.0.6"
+  checksum: 10c0/dd88c220b0e2c6315686289525fd61472d2204d2e4bef4941acfb76bda01d3066f749ac74782aab5b537a45314fcd7d6261eefa40b6ec872691f5803adaa608d
   languageName: node
   linkType: hard
 
@@ -4642,7 +4687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^1.0.1":
+"cookie@npm:^1.0.1, cookie@npm:^1.0.2":
   version: 1.1.1
   resolution: "cookie@npm:1.1.1"
   checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
@@ -5759,6 +5804,7 @@ __metadata:
     globals: "npm:^17.4.0"
     i18next: "npm:^25.8.18"
     i18next-browser-languagedetector: "npm:^8.2.1"
+    msw: "npm:^2.12.14"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
     react-i18next: "npm:^16.5.8"
@@ -6026,6 +6072,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql@npm:^16.12.0":
+  version: 16.13.2
+  resolution: "graphql@npm:16.13.2"
+  checksum: 10c0/64e822a0a0e4398781e4bc9765b88d370c08261498b517add4b878038ef7be2005b6b394a79a5102b9379d57052f60bc7f23fec8f39808d101984a74772ebd9d
+  languageName: node
+  linkType: hard
+
 "handlebars@npm:^4.7.8":
   version: 4.7.8
   resolution: "handlebars@npm:4.7.8"
@@ -6082,6 +6135,13 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"headers-polyfill@npm:^4.0.2":
+  version: 4.0.3
+  resolution: "headers-polyfill@npm:4.0.3"
+  checksum: 10c0/53e85b2c6385f8d411945fb890c5369f1469ce8aa32a6e8d28196df38568148de640c81cf88cbc7c67767103dd9acba48f4f891982da63178fc6e34560022afe
   languageName: node
   linkType: hard
 
@@ -6362,6 +6422,13 @@ __metadata:
   version: 1.0.0
   resolution: "is-interactive@npm:1.0.0"
   checksum: 10c0/dd47904dbf286cd20aa58c5192161be1a67138485b9836d5a70433b21a45442e9611b8498b8ab1f839fc962c7620667a50535fdfb4a6bc7989b8858645c06b4d
+  languageName: node
+  linkType: hard
+
+"is-node-process@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "is-node-process@npm:1.2.0"
+  checksum: 10c0/5b24fda6776d00e42431d7bcd86bce81cb0b6cabeb944142fe7b077a54ada2e155066ad06dbe790abdb397884bdc3151e04a9707b8cd185099efbc79780573ed
   languageName: node
   linkType: hard
 
@@ -7734,6 +7801,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"msw@npm:^2.12.14":
+  version: 2.12.14
+  resolution: "msw@npm:2.12.14"
+  dependencies:
+    "@inquirer/confirm": "npm:^5.0.0"
+    "@mswjs/interceptors": "npm:^0.41.2"
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@types/statuses": "npm:^2.0.6"
+    cookie: "npm:^1.0.2"
+    graphql: "npm:^16.12.0"
+    headers-polyfill: "npm:^4.0.2"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    path-to-regexp: "npm:^6.3.0"
+    picocolors: "npm:^1.1.1"
+    rettime: "npm:^0.10.1"
+    statuses: "npm:^2.0.2"
+    strict-event-emitter: "npm:^0.5.1"
+    tough-cookie: "npm:^6.0.0"
+    type-fest: "npm:^5.2.0"
+    until-async: "npm:^3.0.2"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    typescript: ">= 4.8.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    msw: cli/index.js
+  checksum: 10c0/73e2c08a74bac94036c75aa0340e48573a233d5060cb3098ead7ec0eaddaacef4de399b81e0e3f41ea73d5f92341adc9cf0ae908ad74583d294afa4667e7d277
+  languageName: node
+  linkType: hard
+
 "multer@npm:2.1.1":
   version: 2.1.1
   resolution: "multer@npm:2.1.1"
@@ -7959,6 +8059,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "outvariant@npm:1.4.3"
+  checksum: 10c0/5976ca7740349cb8c71bd3382e2a762b1aeca6f33dc984d9d896acdf3c61f78c3afcf1bfe9cc633a7b3c4b295ec94d292048f83ea2b2594fae4496656eba992c
+  languageName: node
+  linkType: hard
+
 "p-cancelable@npm:^3.0.0":
   version: 3.0.0
   resolution: "p-cancelable@npm:3.0.0"
@@ -8131,6 +8238,13 @@ __metadata:
   version: 8.3.0
   resolution: "path-to-regexp@npm:8.3.0"
   checksum: 10c0/ee1544a73a3f294a97a4c663b0ce71bbf1621d732d80c9c9ed201b3e911a86cb628ebad691b9d40f40a3742fe22011e5a059d8eed2cf63ec2cb94f6fb4efe67c
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
   languageName: node
   linkType: hard
 
@@ -8716,6 +8830,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rettime@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "rettime@npm:0.10.1"
+  checksum: 10c0/94fb30cd13684386c70301c4cff4391bc0c6dc7aeac49364fdfeeaba167897bdb28a58bbb46d1a415f1c5c6240fda3f765cb329e471f37fdc513c739f0b04fbe
+  languageName: node
+  linkType: hard
+
 "reusify@npm:^1.0.4":
   version: 1.1.0
   resolution: "reusify@npm:1.1.0"
@@ -9247,6 +9368,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strict-event-emitter@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "strict-event-emitter@npm:0.5.1"
+  checksum: 10c0/f5228a6e6b6393c57f52f62e673cfe3be3294b35d6f7842fc24b172ae0a6e6c209fa83241d0e433fc267c503bc2f4ffdbe41a9990ff8ffd5ac425ec0489417f7
+  languageName: node
+  linkType: hard
+
 "string-length@npm:^4.0.1":
   version: 4.0.2
   resolution: "string-length@npm:4.0.2"
@@ -9438,6 +9566,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10c0/91d25c9ffb86a91f20522cefb2cbec9b64caa1febe27ad0df52f08993ff60888022d771e868e6416cf2e72dab68449d2139e8709ba009b74c6c7ecd4000048d1
+  languageName: node
+  linkType: hard
+
 "tapable@npm:^2.2.1, tapable@npm:^2.3.0":
   version: 2.3.0
   resolution: "tapable@npm:2.3.0"
@@ -9559,6 +9694,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tldts-core@npm:^7.0.27":
+  version: 7.0.27
+  resolution: "tldts-core@npm:7.0.27"
+  checksum: 10c0/5f148db83b9e5d51a510bd512dd16e158e70eda41bd8a8b39dadc9bd2d969e5342862eee2231d21ed80a1e1c4af6572aea56fba3e38c184f94708942d5141987
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^7.0.5":
+  version: 7.0.27
+  resolution: "tldts@npm:7.0.27"
+  dependencies:
+    tldts-core: "npm:^7.0.27"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/8bd6d2ef27e27560ffca1784067f6ee45ce2eebb0c094126681ed8d42c728904418855dd165c8272039af46a9a8e832990e564c17f5dbff041c5306d50d4cf40
+  languageName: node
+  linkType: hard
+
 "tmpl@npm:1.0.5":
   version: 1.0.5
   resolution: "tmpl@npm:1.0.5"
@@ -9601,6 +9754,15 @@ __metadata:
     "@tokenizer/token": "npm:^0.3.0"
     ieee754: "npm:^1.2.1"
   checksum: 10c0/8786e28e3cb65b9e890bc3c38def98e6dfe4565538237f8c0e47dbe549ed8f5f00de8dc464717868308abb4729f1958f78f69e1c4c3deebbb685729113a6fee8
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "tough-cookie@npm:6.0.1"
+  dependencies:
+    tldts: "npm:^7.0.5"
+  checksum: 10c0/ec70bd6b1215efe4ed31a158f0be3e4c9088fcbd8620edc23a5860d4f3d85c757b77e274baaa700f7b25e409f4181552ed189603c2b2e1a9f88104da3a61a37d
   languageName: node
   linkType: hard
 
@@ -9773,6 +9935,15 @@ __metadata:
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
   checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^5.2.0":
+  version: 5.5.0
+  resolution: "type-fest@npm:5.5.0"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10c0/60bf79a8df45abf99490e3204eceb5cf7f915413f8a69fb578c75cab37ddcb7d29ee21f185f0e1617323ac0b2a441e001b8dc691e220d0b087e9c29ea205538c
   languageName: node
   linkType: hard
 
@@ -10012,6 +10183,13 @@ __metadata:
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
+  languageName: node
+  linkType: hard
+
+"until-async@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "until-async@npm:3.0.2"
+  checksum: 10c0/61c8b03895dbe18fe3d90316d0a1894e0c131ea4b1673f6ce78eed993d0bb81bbf4b7adf8477e9ff7725782a76767eed9d077561cfc9f89b4a1ebe61f7c9828e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What  
Add a demo mode to the frontend that allows the app to be fully navigable without a running backend by mocking all API interactions.

## Changes  

### Configuration  
- Add `VITE_DEMO_MODE` environment variable (`true | false`)  
- Enable demo mode based on env configuration at app startup  

### Mock Layer  
- Implement mock service worker when demo mode is enabled  
- Intercept all outgoing API requests and return mocked responses  
- Add mock implementations for existing endpoints:  
  - `POST /auth/login` → returns a mock admin user with a valid auth structure  
  - `POST /ai/generate-ticket` → returns a mocked generated ticket response   

### Auth Integration  
- Ensure mocked login response correctly populates AuthContext  
- Simulate authenticated state without requiring JWT or cookies  

### UX  
- Add a visible banner indicating the app is running in demo mode  
- Pre-fill login form with demo credentials for one-click access  

## Notes  
- Demo mode only affects frontend behavior; no backend changes required  
- Improve language selection

Closes #17 