### PR TITLE
21 feat: auth add refresh token handling

### DIFF
--- a/backend/src/ai/ai.controller.ts
+++ b/backend/src/ai/ai.controller.ts
@@ -1,8 +1,22 @@
-import { Body, Controller, Post, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
 import { AiService } from './ai.service';
-import { ApiTags, ApiOperation, ApiBody } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBody, ApiCookieAuth } from '@nestjs/swagger';
+import { Roles } from '../auth/decorators/auth.decorators';
+import { JwtGuard } from '../auth/guards/jwt.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Role } from '../users/user.entity';
 
 @ApiTags('AI')
+@ApiCookieAuth()
+@UseGuards(JwtGuard, RolesGuard)
+@Roles(Role.ADMIN)
 @Controller('ai')
 export class AiController {
   constructor(private readonly aiService: AiService) {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { UsersModule } from './users/users.module';
 import { User } from './users/user.entity';
 import { AuthModule } from './auth/auth.module';
 import { SeedModule } from './seed/seed.module';
+import { RefreshToken } from './auth/refresh-token.entity';
 
 @Module({
   imports: [
@@ -21,7 +22,7 @@ import { SeedModule } from './seed/seed.module';
         username: config.get<string>('DB_USERNAME', 'teamflow'),
         password: config.get<string>('DB_PASSWORD', 'teamflow'),
         database: config.get<string>('DB_NAME', 'teamflow'),
-        entities: [User],
+        entities: [User, RefreshToken],
         synchronize: true,
       }),
     }),

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,20 +1,46 @@
 import {
-  Body,
   Controller,
   Post,
   HttpCode,
   HttpStatus,
+  Body,
   Res,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
-import { Response } from 'express';
+import { Response, Request } from 'express';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
+import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
+
+const COOKIE_BASE = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict' as const,
+};
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  private setTokenCookies(
+    res: Response,
+    accessToken: string,
+    refreshToken: string,
+  ): void {
+    res.cookie('access_token', accessToken, {
+      ...COOKIE_BASE,
+      // maxAge: 15 * 60 * 1000,
+      maxAge: 5000,
+    });
+    res.cookie('refresh_token', refreshToken, {
+      ...COOKIE_BASE,
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+      path: '/api/auth/refresh',
+    });
+  }
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
@@ -23,15 +49,38 @@ export class AuthController {
     @Body() dto: LoginDto,
     @Res({ passthrough: true }) res: Response,
   ) {
-    const { accessToken, user } = await this.authService.login(dto);
-
-    res.cookie('access_token', accessToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
-      maxAge: 15 * 60 * 1000,
-    });
-
+    const { accessToken, refreshToken, user } =
+      await this.authService.login(dto);
+    this.setTokenCookies(res, accessToken, refreshToken);
     return { user };
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtRefreshGuard)
+  @ApiOperation({ summary: 'Rotate access + refresh token pair' })
+  async refresh(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const rawToken = req.user as string;
+    const { accessToken, refreshToken, user } =
+      await this.authService.refresh(rawToken);
+    this.setTokenCookies(res, accessToken, refreshToken);
+    return { user };
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Revoke refresh token and clear cookies' })
+  async logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const token = (req.cookies as Record<string, string>)?.refresh_token;
+    if (token) await this.authService.logout(token);
+
+    res.clearCookie('access_token', COOKIE_BASE);
+    res.clearCookie('refresh_token', {
+      ...COOKIE_BASE,
+      path: 'api/auth/refresh',
+    });
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,16 +1,19 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-import { JwtStrategy } from './jwt.strategy';
+import { JwtStrategy } from './strategies/jwt.strategy';
+import { RefreshToken } from './refresh-token.entity';
 import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
     PassportModule,
     UsersModule,
+    TypeOrmModule.forFeature([RefreshToken]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -5,6 +5,13 @@ import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import * as bcrypt from 'bcrypt';
 import { Role, User } from '../users/user.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { RefreshToken } from './refresh-token.entity';
+import * as crypto from 'crypto';
+
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+}));
 
 const mockUser: User = {
   id: 'uuid-123',
@@ -16,6 +23,16 @@ const mockUser: User = {
   updatedAt: new Date(),
 };
 
+const mockStoredToken: RefreshToken = {
+  id: 'uuid-456',
+  tokenHash: 'hashed',
+  revoked: false,
+  expiresAt: new Date(Date.now() + 1000 * 60 * 60),
+  user: mockUser,
+  userId: mockUser.id,
+  createdAt: new Date(),
+};
+
 const mockUsersService = {
   findByEmail: jest.fn(),
 };
@@ -24,15 +41,32 @@ const mockJwtService = {
   sign: jest.fn().mockReturnValue('mock-jwt-token'),
 };
 
+const mockRefreshTokenRepo = {
+  findOne: jest.fn(),
+  save: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+};
+
 async function buildModule(): Promise<TestingModule> {
   return Test.createTestingModule({
     providers: [
       AuthService,
       { provide: UsersService, useValue: mockUsersService },
       { provide: JwtService, useValue: mockJwtService },
+      {
+        provide: getRepositoryToken(RefreshToken),
+        useValue: mockRefreshTokenRepo,
+      },
     ],
   }).compile();
 }
+
+const rawLogoutToken = 'some-raw-token';
+const expectedLogoutHash = crypto
+  .createHash('sha256')
+  .update(rawLogoutToken)
+  .digest('hex');
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -46,7 +80,7 @@ describe('AuthService', () => {
   describe('login', () => {
     it('should return accessToken and user on valid credentials', async () => {
       mockUsersService.findByEmail.mockResolvedValue(mockUser);
-      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
       const result = await service.login({
         email: 'admin@teamflow.com',
@@ -63,7 +97,7 @@ describe('AuthService', () => {
 
     it('should throw UnauthorizedException on invalid password', async () => {
       mockUsersService.findByEmail.mockResolvedValue(mockUser);
-      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
       await expect(
         service.login({
@@ -114,6 +148,95 @@ describe('AuthService', () => {
 
       expect((errorNotFound as UnauthorizedException).message).toBe(
         (errorWrongPassword as UnauthorizedException).message,
+      );
+    });
+  });
+
+  describe('refresh', () => {
+    const rawToken = 'valid-raw-token';
+
+    it('should issue new tokens on valid refresh token', async () => {
+      mockRefreshTokenRepo.findOne.mockResolvedValue(mockStoredToken);
+      mockRefreshTokenRepo.save.mockResolvedValue(mockStoredToken);
+      mockRefreshTokenRepo.create.mockImplementation(
+        (data) => data as RefreshToken,
+      );
+
+      const result = await service.refresh(rawToken);
+
+      expect(result.accessToken).toBe('mock-jwt-token');
+      expect(result.user).toEqual({
+        id: mockUser.id,
+        email: mockUser.email,
+        role: mockUser.role,
+      });
+    });
+
+    it('should revoke the old token on refresh (rotation)', async () => {
+      mockRefreshTokenRepo.findOne.mockResolvedValue({ ...mockStoredToken });
+      mockRefreshTokenRepo.save.mockResolvedValue({});
+      mockRefreshTokenRepo.create.mockImplementation(
+        (data) => data as RefreshToken,
+      );
+
+      await service.refresh(rawToken);
+
+      expect(mockRefreshTokenRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ revoked: true }),
+      );
+    });
+
+    it('should throw when token is not found or already revoked', async () => {
+      mockRefreshTokenRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.refresh(rawToken)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw when token is expired', async () => {
+      mockRefreshTokenRepo.findOne.mockResolvedValue({
+        ...mockStoredToken,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+
+      await expect(service.refresh(rawToken)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw when user is not active', async () => {
+      mockRefreshTokenRepo.findOne.mockResolvedValue({
+        ...mockStoredToken,
+        user: { ...mockUser, isActive: false },
+      });
+
+      await expect(service.refresh(rawToken)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('should revoke the refresh token', async () => {
+      mockRefreshTokenRepo.update.mockResolvedValue({});
+
+      await service.logout('some-raw-token');
+
+      expect(mockRefreshTokenRepo.update).toHaveBeenCalledWith(
+        { tokenHash: expectedLogoutHash },
+        { revoked: true },
+      );
+    });
+
+    it('should hash the token before revoking', async () => {
+      mockRefreshTokenRepo.update.mockResolvedValue({});
+
+      await service.logout('plain-token');
+
+      expect(mockRefreshTokenRepo.update).not.toHaveBeenCalledWith(
+        { tokenHash: rawLogoutToken },
+        expect.anything(),
       );
     });
   });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,13 +1,18 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { UsersService } from '../users/users.service';
-import * as bcrypt from 'bcrypt';
-import { JwtPayload } from './jwt.strategy';
-import { User } from '../users/user.entity';
+import { RefreshToken } from './refresh-token.entity';
 import { LoginDto } from './dto/login.dto';
+import { JwtPayload } from './strategies/jwt.strategy';
+import { User } from '../users/user.entity';
+import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
 
-export type LoginResponse = {
+export type AuthTokens = {
   accessToken: string;
+  refreshToken: string;
   user: Pick<User, 'id' | 'email' | 'role'>;
 };
 
@@ -16,9 +21,28 @@ export class AuthService {
   constructor(
     private usersService: UsersService,
     private jwtService: JwtService,
+    @InjectRepository(RefreshToken)
+    private refreshTokenRepo: Repository<RefreshToken>,
   ) {}
 
-  async login(dto: LoginDto): Promise<LoginResponse> {
+  private hashToken(raw: string): string {
+    return crypto.createHash('sha256').update(raw).digest('hex');
+  }
+
+  private generateRefreshToken(): string {
+    return crypto.randomBytes(64).toString('hex');
+  }
+
+  private buildAccessToken(user: User): string {
+    const payload: JwtPayload = {
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+    };
+    return this.jwtService.sign(payload);
+  }
+
+  async login(dto: LoginDto): Promise<AuthTokens> {
     const user = await this.usersService.findByEmail(dto.email);
 
     if (!user || !user.isActive) {
@@ -30,19 +54,58 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    const payload: JwtPayload = {
-      sub: user.id,
-      email: user.email,
-      role: user.role,
-    };
+    return this.issueTokens(user);
+  }
+
+  async refresh(rawRefreshToken: string): Promise<AuthTokens> {
+    const hash = this.hashToken(rawRefreshToken);
+
+    const stored = await this.refreshTokenRepo.findOne({
+      where: { tokenHash: hash, revoked: false },
+      relations: ['user'],
+    });
+
+    // Token not found, expired or revoked
+    if (!stored || stored.expiresAt < new Date()) {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    if (!stored.user.isActive) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    // Rotation: revoke old token, emit a new one
+    stored.revoked = true;
+    await this.refreshTokenRepo.save(stored);
+
+    return this.issueTokens(stored.user);
+  }
+
+  async logout(rawRefreshToken: string): Promise<void> {
+    const hash = this.hashToken(rawRefreshToken);
+    await this.refreshTokenRepo.update({ tokenHash: hash }, { revoked: true });
+  }
+
+  private async issueTokens(user: User): Promise<AuthTokens> {
+    const rawRefreshToken = this.generateRefreshToken();
+    const hash = this.hashToken(rawRefreshToken);
+
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 7);
+
+    await this.refreshTokenRepo.save(
+      this.refreshTokenRepo.create({
+        tokenHash: hash,
+        userId: user.id,
+        user,
+        expiresAt,
+      }),
+    );
 
     return {
-      accessToken: this.jwtService.sign(payload),
-      user: {
-        id: user.id,
-        email: user.email,
-        role: user.role,
-      },
+      accessToken: this.buildAccessToken(user),
+      refreshToken: rawRefreshToken,
+      user: { id: user.id, email: user.email, role: user.role },
     };
   }
 }

--- a/backend/src/auth/guards/jwt-refresh.guard.ts
+++ b/backend/src/auth/guards/jwt-refresh.guard.ts
@@ -1,0 +1,20 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+@Injectable()
+export class JwtRefreshGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request>();
+    const token = (req.cookies as Record<string, string>)?.refresh_token;
+
+    if (!token) throw new UnauthorizedException('Refresh token missing');
+
+    req.user = token as unknown as Express.User;
+    return true;
+  }
+}

--- a/backend/src/auth/refresh-token.entity.ts
+++ b/backend/src/auth/refresh-token.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+@Entity('refresh_tokens')
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index()
+  @Column()
+  tokenHash!: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user!: User;
+
+  @Column()
+  userId!: string;
+
+  @Column()
+  expiresAt!: Date;
+
+  @Column({ default: false })
+  revoked!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -3,7 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
-import { Role } from '../users/user.entity';
+import { Role } from '../../users/user.entity';
 
 export type JwtPayload = {
   sub: string;

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -26,6 +26,7 @@ async function bootstrap() {
     .setTitle('TeamFlow API')
     .setDescription('TeamFlow REST API documentation')
     .setVersion('1.0')
+    .addCookieAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, swaggerConfig);

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -5,16 +5,25 @@ import { Role, User } from './user.entity';
 import { Roles } from '../auth/decorators/auth.decorators';
 import { JwtGuard } from '../auth/guards/jwt.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
+import { ApiCookieAuth } from '@nestjs/swagger';
 
 @Crud({
   model: { type: User },
   routes: {
     only: ['getManyBase', 'getOneBase', 'updateOneBase', 'deleteOneBase'],
   },
+  params: {
+    id: {
+      field: 'id',
+      type: 'uuid',
+      primary: true,
+    },
+  },
   query: {
     exclude: ['passwordHash'],
   },
 })
+@ApiCookieAuth()
 @Controller('users')
 @UseGuards(JwtGuard, RolesGuard)
 @Roles(Role.ADMIN)

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",

--- a/frontend/src/api/ai.ts
+++ b/frontend/src/api/ai.ts
@@ -1,14 +1,11 @@
-import axios from "axios";
 import type { GeneratedTicket } from "../types/generatedTicket";
+import { api } from "./axios.instance";
 
 export async function generateTicket(
   customerRequest: string,
 ): Promise<GeneratedTicket> {
-  const response = await axios.post<GeneratedTicket>(
-    "/api/ai/generate-ticket",
-    {
-      customerRequest,
-    },
-  );
+  const response = await api.post<GeneratedTicket>("/ai/generate-ticket", {
+    customerRequest,
+  });
   return response.data;
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -13,6 +13,15 @@ export async function login(
   return response.data.user;
 }
 
-// export async function logout(): Promise<void> {
-//   await axios.post("/api/auth/logout", {}, { withCredentials: true });
-// }
+export async function refreshToken(): Promise<AuthUser> {
+  const response = await axios.post<{ user: AuthUser }>(
+    "/api/auth/refresh",
+    {},
+    { withCredentials: true },
+  );
+  return response.data.user;
+}
+
+export async function logout(): Promise<void> {
+  await axios.post("/api/auth/logout", {}, { withCredentials: true });
+}

--- a/frontend/src/api/axios.instance.ts
+++ b/frontend/src/api/axios.instance.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: "/api",
+  withCredentials: true,
+});

--- a/frontend/src/providers/AuthProvider.test.tsx
+++ b/frontend/src/providers/AuthProvider.test.tsx
@@ -1,0 +1,203 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { AxiosError } from "axios";
+import { AuthProvider } from "./AuthProvider";
+import { api } from "../api/axios.instance";
+import { refreshToken, logout as logoutApi } from "../api/auth";
+
+vi.mock("../api/auth", () => ({
+  refreshToken: vi.fn(),
+  logout: vi.fn(),
+}));
+
+const mockRefreshToken = refreshToken as Mock;
+const mockLogoutApi = logoutApi as Mock;
+
+function make401Error(url = "/api/some-endpoint"): AxiosError {
+  const error = new AxiosError("Unauthorized");
+  error.response = {
+    status: 401,
+    data: {},
+    headers: {},
+    config: {},
+    statusText: "Unauthorized",
+  } as never;
+  error.config = { url } as never;
+  return error;
+}
+
+async function mountProvider() {
+  const utils = render(
+    <AuthProvider>
+      <div data-testid="child" />
+    </AuthProvider>,
+  );
+  await waitFor(() => expect(utils.getByTestId("child")).toBeInTheDocument());
+  return utils;
+}
+
+function getInterceptorErrorHandler() {
+  const handlers = api.interceptors.response.handlers as Array<{
+    fulfilled: unknown;
+    rejected: (e: unknown) => unknown;
+  }>;
+  const last = handlers.at(-1);
+  if (!last) throw new Error("Nessun interceptor registrato");
+  return last.rejected;
+}
+
+describe("AuthProvider — interceptor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRefreshToken.mockResolvedValue({
+      id: "1",
+      email: "u@test.com",
+      role: "user",
+    });
+  });
+
+  it("should not intercept non-401 errors", async () => {
+    await mountProvider();
+    const handler = getInterceptorErrorHandler();
+
+    const error = new AxiosError("Server error");
+    error.response = { status: 500 } as never;
+    error.config = { url: "/api/other" } as never;
+
+    await expect(handler(error)).rejects.toThrow("Server error");
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not intercept 401 on /auth/refresh (avoid infinite loop)", async () => {
+    await mountProvider();
+    const handler = getInterceptorErrorHandler();
+
+    const error = make401Error("/api/auth/refresh");
+    await expect(handler(error)).rejects.toBeDefined();
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not intercept 401 on /auth/login", async () => {
+    await mountProvider();
+    const handler = getInterceptorErrorHandler();
+
+    const error = make401Error("/api/auth/login");
+    await expect(handler(error)).rejects.toBeDefined();
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call refreshToken and retry original request on 401", async () => {
+    await mountProvider();
+
+    mockRefreshToken.mockResolvedValue({
+      id: "1",
+      email: "u@test.com",
+      role: "user",
+    });
+
+    const retrySpy = vi
+      .spyOn(api, "request")
+      .mockResolvedValue({ data: "retried" });
+    const handler = getInterceptorErrorHandler();
+
+    await handler(make401Error());
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(2);
+    expect(retrySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should logout and reject if refreshToken fails", async () => {
+    await mountProvider();
+    mockLogoutApi.mockResolvedValue(undefined);
+    mockRefreshToken.mockRejectedValue(new Error("Refresh failed"));
+
+    const handler = getInterceptorErrorHandler();
+
+    await expect(handler(make401Error())).rejects.toThrow("Refresh failed");
+
+    await waitFor(() => {
+      expect(mockLogoutApi).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should queue concurrent 401s while refreshing and flush them on success", async () => {
+    await mountProvider();
+
+    let resolveRefresh!: () => void;
+    mockRefreshToken.mockReturnValue(
+      new Promise<void>((res) => {
+        resolveRefresh = res;
+      }),
+    );
+
+    const retrySpy = vi
+      .spyOn(api, "request")
+      .mockResolvedValue({ data: "retried" });
+
+    const handler = getInterceptorErrorHandler();
+
+    const p1 = handler(make401Error("/api/resource-1"));
+    const p2 = handler(make401Error("/api/resource-2"));
+    const p3 = handler(make401Error("/api/resource-3"));
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(2);
+
+    resolveRefresh();
+
+    await Promise.all([p1, p2, p3]);
+
+    expect(retrySpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("should reject all queued requests if refresh fails", async () => {
+    await mountProvider();
+    mockLogoutApi.mockResolvedValue(undefined);
+
+    let rejectRefresh!: (e: Error) => void;
+    mockRefreshToken.mockReturnValue(
+      new Promise<void>((_, rej) => {
+        rejectRefresh = rej;
+      }),
+    );
+
+    const handler = getInterceptorErrorHandler();
+
+    const p1 = handler(make401Error("/api/resource-1"));
+    const p2 = handler(make401Error("/api/resource-2"));
+
+    rejectRefresh(new Error("Token expired"));
+
+    await expect(p1).rejects.toThrow("Token expired");
+    await expect(p2).rejects.toThrow("Token expired");
+  });
+
+  it("should eject interceptor on unmount", async () => {
+    const ejectSpy = vi.spyOn(api.interceptors.response, "eject");
+    const { unmount } = await mountProvider();
+
+    unmount();
+
+    expect(ejectSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AuthProvider — inizializzazione", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should set user on successful initial refresh", async () => {
+    const mockUser = { id: "1", email: "u@test.com", role: "user" };
+    mockRefreshToken.mockResolvedValue(mockUser);
+
+    await mountProvider();
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("should set user to null if initial refresh fails", async () => {
+    mockRefreshToken.mockRejectedValue(new Error("No session"));
+
+    await mountProvider();
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -1,17 +1,97 @@
-import { useState, type PropsWithChildren } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  type PropsWithChildren,
+} from "react";
 import type { AuthUser } from "../types/authUser";
 import { AuthContext } from "./Auth.Context";
+import { refreshToken, logout as logoutApi } from "../api/auth";
+import { api } from "../api/axios.instance";
+
+const isDemoMode = import.meta.env.VITE_DEMO_MODE === "true";
 
 export function AuthProvider({ children }: PropsWithChildren) {
   const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const logout = useCallback(async () => {
+    try {
+      await logoutApi();
+    } finally {
+      setUser(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    let isRefreshing = false;
+    let pendingQueue: Array<{
+      resolve: () => void;
+      reject: (reason?: unknown) => void;
+    }> = [];
+
+    function flushQueue(error: unknown = null): void {
+      pendingQueue.forEach(({ resolve, reject }) =>
+        error ? reject(error) : resolve(),
+      );
+      pendingQueue = [];
+    }
+
+    const SKIP_REFRESH_URLS = ["/auth/refresh", "/auth/login"];
+
+    const interceptorId = api.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        const requestUrl: string = error.config?.url ?? "";
+
+        if (
+          error.response?.status !== 401 ||
+          SKIP_REFRESH_URLS.some((url) => requestUrl.includes(url)) ||
+          isDemoMode
+        ) {
+          return Promise.reject(error);
+        }
+
+        if (isRefreshing) {
+          return new Promise<void>((resolve, reject) => {
+            pendingQueue.push({ resolve, reject });
+          }).then(() => api.request(error.config));
+        }
+
+        isRefreshing = true;
+
+        try {
+          await refreshToken();
+          flushQueue();
+          return api.request(error.config);
+        } catch (refreshError) {
+          flushQueue(refreshError);
+          logout();
+          return Promise.reject(refreshError);
+        } finally {
+          isRefreshing = false;
+        }
+      },
+    );
+
+    // Remove the interceptor when the component unmounts
+    return () => api.interceptors.response.eject(interceptorId);
+  }, [logout]);
+
+  useEffect(() => {
+    if (isDemoMode) setIsLoading(false);
+    else
+      refreshToken()
+        .then(setUser)
+        .catch(() => setUser(null))
+        .finally(() => setIsLoading(false));
+  }, []);
+
+  if (isLoading) return null;
 
   return (
     <AuthContext.Provider
-      value={{
-        user,
-        setUser,
-        isAuthenticated: user !== null,
-      }}
+      value={{ user, setUser, isAuthenticated: user !== null }}
     >
       {children}
     </AuthContext.Provider>


### PR DESCRIPTION
## What
Add refresh token services and interceptor

## Changes

### Backend
- Add refresh service and guard
- Add guard to ai controller
- Add cookie handling to swagger
- Fix swagger user id type
- Add refresh and logout service test

### Frontend
- Add axios interceptor to queue failed API due to expired access token, call the refresh service and call the queued API again
- Add tests for `AuthProvider`

Closes #21