### PR TITLE
47 feat auth change password

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -9,10 +9,13 @@ import {
   Req,
 } from '@nestjs/common';
 import { Response, Request } from 'express';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiCookieAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
+import { JwtGuard } from './guards/jwt.guard';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { JwtUser } from './strategies/jwt.strategy';
 
 const COOKIE_BASE = {
   httpOnly: true,
@@ -81,5 +84,32 @@ export class AuthController {
       ...COOKIE_BASE,
       path: 'api/auth/refresh',
     });
+  }
+
+  @Post('change-password')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtGuard)
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: 'Change own password — invalidates all other active sessions',
+  })
+  async changePassword(
+    @Req() req: Request,
+    @Body() dto: ChangePasswordDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const currentUser = req.user as JwtUser;
+    const currentRawRefreshToken = (req.cookies as Record<string, string>)
+      ?.refresh_token;
+
+    const { accessToken, refreshToken, user } =
+      await this.authService.changePassword(
+        currentUser.id,
+        dto,
+        currentRawRefreshToken,
+      );
+
+    this.setTokenCookies(res, accessToken, refreshToken);
+    return { user };
   }
 }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
 import { UnauthorizedException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { Not } from 'typeorm';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { Role, User } from '../users/user.entity';
@@ -11,6 +12,7 @@ import * as crypto from 'crypto';
 
 jest.mock('bcrypt', () => ({
   compare: jest.fn(),
+  hashSync: jest.fn().mockReturnValue('dummy-hash'),
 }));
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -40,6 +42,8 @@ const mockStoredToken: RefreshToken = {
 
 const mockUsersService = {
   findByEmail: jest.fn(),
+  findOneBy: jest.fn(),
+  updatePassword: jest.fn(),
 };
 
 const mockJwtService = {
@@ -75,6 +79,12 @@ const rawLogoutToken = 'some-raw-token';
 const expectedLogoutHash = crypto
   .createHash('sha256')
   .update(rawLogoutToken)
+  .digest('hex');
+
+const rawChangePasswordToken = 'current-session-token';
+const expectedChangePasswordHash = crypto
+  .createHash('sha256')
+  .update(rawChangePasswordToken)
   .digest('hex');
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -268,6 +278,166 @@ describe('AuthService', () => {
       expect(mockRefreshTokenRepo.update).not.toHaveBeenCalledWith(
         { tokenHash: rawLogoutToken },
         expect.anything(),
+      );
+    });
+  });
+
+  // ── changePassword ─────────────────────────────────────────────────────────
+
+  describe('changePassword', () => {
+    const dto = { currentPassword: 'old-pass', newPassword: 'new-pass' };
+
+    beforeEach(() => {
+      mockRefreshTokenRepo.create.mockImplementation(
+        (data) => data as RefreshToken,
+      );
+      mockRefreshTokenRepo.save.mockImplementation((data) =>
+        Promise.resolve(data as RefreshToken),
+      );
+      mockRefreshTokenRepo.update.mockResolvedValue({});
+      mockUsersService.updatePassword.mockResolvedValue(undefined);
+    });
+
+    it('should return new tokens when credentials are valid', async () => {
+      mockUsersService.findOneBy
+        .mockResolvedValueOnce(mockUser) // initial lookup
+        .mockResolvedValueOnce(mockUser); // post-update lookup
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.changePassword(mockUser.id, dto, undefined);
+
+      expect(result.accessToken).toBe('mock-jwt-token');
+      expect(result.user).toEqual({
+        id: mockUser.id,
+        email: mockUser.email,
+        role: mockUser.role,
+        fullName: mockUser.fullName,
+      });
+    });
+
+    it('should return a new refreshToken after a successful password change', async () => {
+      mockUsersService.findOneBy
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.changePassword(mockUser.id, dto, undefined);
+
+      expect(result.refreshToken).toBeDefined();
+      expect(typeof result.refreshToken).toBe('string');
+    });
+
+    it('should throw UnauthorizedException when user is not found', async () => {
+      mockUsersService.findOneBy.mockResolvedValue(null);
+
+      await expect(
+        service.changePassword(mockUser.id, dto, undefined),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException when user is not active', async () => {
+      mockUsersService.findOneBy.mockResolvedValue({
+        ...mockUser,
+        isActive: false,
+      });
+
+      await expect(
+        service.changePassword(mockUser.id, dto, undefined),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException when the current password is wrong', async () => {
+      mockUsersService.findOneBy.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(
+        service.changePassword(mockUser.id, dto, undefined),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException when updatedUser is not found after password update', async () => {
+      mockUsersService.findOneBy
+        .mockResolvedValueOnce(mockUser) // initial lookup succeeds
+        .mockResolvedValueOnce(null); // post-update lookup returns nothing
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await expect(
+        service.changePassword(mockUser.id, dto, undefined),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should revoke all user tokens when no currentRawRefreshToken is provided', async () => {
+      mockUsersService.findOneBy
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.changePassword(mockUser.id, dto, undefined);
+
+      expect(mockRefreshTokenRepo.update).toHaveBeenCalledWith(
+        { userId: mockUser.id, revoked: false },
+        { revoked: true },
+      );
+    });
+
+    it('should revoke all OTHER tokens (excluding the current session) when currentRawRefreshToken is provided', async () => {
+      mockUsersService.findOneBy
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.changePassword(mockUser.id, dto, rawChangePasswordToken);
+
+      expect(mockRefreshTokenRepo.update).toHaveBeenCalledWith(
+        {
+          userId: mockUser.id,
+          revoked: false,
+          tokenHash: Not(expectedChangePasswordHash),
+        },
+        { revoked: true },
+      );
+    });
+
+    it('should also revoke the current session token after revoking the others', async () => {
+      mockUsersService.findOneBy
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.changePassword(mockUser.id, dto, rawChangePasswordToken);
+
+      expect(mockRefreshTokenRepo.update).toHaveBeenCalledWith(
+        { tokenHash: expectedChangePasswordHash },
+        { revoked: true },
+      );
+    });
+
+    it('should hash the current session token and never use it in plain text', async () => {
+      mockUsersService.findOneBy
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.changePassword(mockUser.id, dto, rawChangePasswordToken);
+
+      const allCalls = mockRefreshTokenRepo.update.mock.calls;
+      const usedRawToken = allCalls.some((args) =>
+        JSON.stringify(args).includes(rawChangePasswordToken),
+      );
+      expect(usedRawToken).toBe(false);
+    });
+
+    it('should call updatePassword with the correct userId and new password', async () => {
+      mockUsersService.findOneBy
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.changePassword(mockUser.id, dto, undefined);
+
+      expect(mockUsersService.updatePassword).toHaveBeenCalledWith(
+        mockUser.id,
+        dto.newPassword,
       );
     });
   });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
 import { UsersService } from '../users/users.service';
 import { RefreshToken } from './refresh-token.entity';
 import { LoginDto } from './dto/login.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 import { JwtPayload } from './strategies/jwt.strategy';
 import { User } from '../users/user.entity';
 import * as bcrypt from 'bcrypt';
@@ -16,6 +17,8 @@ export type AuthTokens = {
   refreshToken: string;
   user: Pick<User, 'id' | 'email' | 'role' | 'fullName'>;
 };
+
+const DUMMY_HASH = bcrypt.hashSync('dummy-timing-protection', 10);
 
 @Injectable()
 export class AuthService {
@@ -47,12 +50,11 @@ export class AuthService {
   async login(dto: LoginDto): Promise<AuthTokens> {
     const user = await this.usersService.findByEmail(dto.email);
 
-    if (!user || !user.isActive) {
-      throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
-    }
+    // Always execute bcrypt.compare to avoid timing attack
+    const hashToCheck = user?.passwordHash ?? DUMMY_HASH;
+    const passwordMatch = await bcrypt.compare(dto.password, hashToCheck);
 
-    const passwordMatch = await bcrypt.compare(dto.password, user.passwordHash);
-    if (!passwordMatch) {
+    if (!user || !user.isActive || !passwordMatch) {
       throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
     }
 
@@ -88,6 +90,52 @@ export class AuthService {
   async logout(rawRefreshToken: string): Promise<void> {
     const hash = this.hashToken(rawRefreshToken);
     await this.refreshTokenRepo.update({ tokenHash: hash }, { revoked: true });
+  }
+
+  async changePassword(
+    userId: string,
+    dto: ChangePasswordDto,
+    currentRawRefreshToken: string | undefined,
+  ): Promise<AuthTokens> {
+    const user = await this.usersService.findOneBy({ id: userId });
+
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    const passwordMatch = await bcrypt.compare(
+      dto.currentPassword,
+      user.passwordHash,
+    );
+    if (!passwordMatch) {
+      throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    await this.usersService.updatePassword(userId, dto.newPassword);
+
+    if (currentRawRefreshToken) {
+      const currentHash = this.hashToken(currentRawRefreshToken);
+      await this.refreshTokenRepo.update(
+        { userId, revoked: false, tokenHash: Not(currentHash) },
+        { revoked: true },
+      );
+      await this.refreshTokenRepo.update(
+        { tokenHash: currentHash },
+        { revoked: true },
+      );
+    } else {
+      await this.refreshTokenRepo.update(
+        { userId, revoked: false },
+        { revoked: true },
+      );
+    }
+
+    const updatedUser = await this.usersService.findOneBy({ id: userId });
+    if (!updatedUser) {
+      throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    return this.issueTokens(updatedUser);
   }
 
   private async issueTokens(user: User): Promise<AuthTokens> {

--- a/backend/src/auth/dto/change-password.dto.ts
+++ b/backend/src/auth/dto/change-password.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @ApiProperty({ example: 'currentPassword123' })
+  @IsString()
+  currentPassword!: string;
+
+  @ApiProperty({ example: 'newPassword456' })
+  @IsString()
+  @MinLength(6)
+  newPassword!: string;
+}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -28,10 +28,10 @@ export class UsersService extends TypeOrmCrudService<User> {
     });
 
     if (existing) {
-      if (!existing.isActive) {
-        throw new ConflictException(ErrorCode.USER_INACTIVE);
+      if (existing.isActive) {
+        throw new ConflictException(ErrorCode.USER_EMAIL_ALREADY_EXISTS);
       }
-      throw new ConflictException(ErrorCode.USER_EMAIL_ALREADY_EXISTS);
+      throw new ConflictException(ErrorCode.USER_INACTIVE);
     }
 
     const passwordHash = await bcrypt.hash(dto.password, 10);
@@ -57,5 +57,10 @@ export class UsersService extends TypeOrmCrudService<User> {
 
     user.isActive = true;
     return this.repo.save(user);
+  }
+
+  async updatePassword(id: string, newPassword: string): Promise<void> {
+    const passwordHash = await bcrypt.hash(newPassword, 10);
+    await this.repo.update(id, { passwordHash });
   }
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import type { AuthUser } from "../types/authUser";
+import { api } from "./axios.instance";
 
 export async function login(
   email: string,
@@ -23,5 +24,16 @@ export async function refreshToken(): Promise<AuthUser> {
 }
 
 export async function logout(): Promise<void> {
-  await axios.post("/api/auth/logout", {}, { withCredentials: true });
+  await api.post("/auth/logout", {}, { withCredentials: true });
+}
+
+export async function changePassword(
+  currentPassword: string,
+  newPassword: string,
+): Promise<AuthUser> {
+  const response = await api.post<{ user: AuthUser }>("/auth/change-password", {
+    currentPassword,
+    newPassword,
+  });
+  return response.data.user;
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -20,6 +20,7 @@ import useLogoutMutation from "../hooks/auth/useLogoutMutation";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import PasswordIcon from "@mui/icons-material/Password";
+import { useAuth } from "../providers/useAuth";
 
 const isDemoMode = import.meta.env.VITE_DEMO_MODE === "true";
 
@@ -38,6 +39,7 @@ function resolveLanguageCode(lng: string): LanguageCode {
 export default function Header() {
   const { i18n, t } = useTranslation("common");
   const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
 
   const logoutMutation = useLogoutMutation();
 
@@ -98,14 +100,16 @@ export default function Header() {
               </MenuItem>
             ))}
           </Select>
-          <IconButton
-            title={t("settings")}
-            onClick={(e) => {
-              setAnchorEl(e.currentTarget);
-            }}
-          >
-            <SettingsIcon />
-          </IconButton>
+          {isAuthenticated && (
+            <IconButton
+              title={t("settings")}
+              onClick={(e) => {
+                setAnchorEl(e.currentTarget);
+              }}
+            >
+              <SettingsIcon />
+            </IconButton>
+          )}
           <Menu
             open={!!anchorEl}
             anchorEl={anchorEl}
@@ -113,10 +117,10 @@ export default function Header() {
               setAnchorEl(null);
             }}
           >
-            {/* TODO: Add change password logic */}
             <MenuItem
               onClick={() => {
                 setAnchorEl(null);
+                navigate("/change-password");
               }}
             >
               <ListItemIcon>

--- a/frontend/src/forms/auth/ChangePasswordForm.tsx
+++ b/frontend/src/forms/auth/ChangePasswordForm.tsx
@@ -1,0 +1,35 @@
+import { Stack } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { ControlledPasswordField } from "../../components/ControlledPasswordField";
+
+type ChangePasswordFormProps = { onEnter?: () => void };
+
+export function ChangePasswordForm({ onEnter }: ChangePasswordFormProps) {
+  const { t } = useTranslation("auth");
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") onEnter?.();
+  };
+
+  return (
+    <Stack spacing={2}>
+      <ControlledPasswordField
+        name="currentPassword"
+        label={t("currentPassword")}
+        onKeyDown={handleKeyDown}
+      />
+
+      <ControlledPasswordField
+        name="newPassword"
+        label={t("newPassword")}
+        onKeyDown={handleKeyDown}
+      />
+
+      <ControlledPasswordField
+        name="confirmNewPassword"
+        label={t("confirmNewPassword")}
+        onKeyDown={handleKeyDown}
+      />
+    </Stack>
+  );
+}

--- a/frontend/src/forms/auth/LoginForm.tsx
+++ b/frontend/src/forms/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import { Stack } from "@mui/material";
-import { ControlledTextField } from "../components/ControlledTextField";
+import { ControlledTextField } from "../../components/ControlledTextField";
 import { useTranslation } from "react-i18next";
-import { ControlledPasswordField } from "../components/ControlledPasswordField";
+import { ControlledPasswordField } from "../../components/ControlledPasswordField";
 
 type LoginFormProps = { onEnter?: () => void };
 
@@ -13,7 +13,7 @@ export function LoginForm({ onEnter }: LoginFormProps) {
       <ControlledTextField
         name="email"
         fullWidth
-        label={t("login.email")}
+        label={t("email")}
         type="email"
         onKeyDown={(e) => {
           if (e.key === "Enter") onEnter?.();
@@ -23,7 +23,7 @@ export function LoginForm({ onEnter }: LoginFormProps) {
       <ControlledPasswordField
         name="password"
         fullWidth
-        label={t("login.password")}
+        label={t("password")}
         type="password"
         onKeyDown={(e) => {
           if (e.key === "Enter") onEnter?.();

--- a/frontend/src/forms/auth/LoginForm.tsx
+++ b/frontend/src/forms/auth/LoginForm.tsx
@@ -13,7 +13,7 @@ export function LoginForm({ onEnter }: LoginFormProps) {
       <ControlledTextField
         name="email"
         fullWidth
-        label={t("email")}
+        label={t("login.email")}
         type="email"
         onKeyDown={(e) => {
           if (e.key === "Enter") onEnter?.();
@@ -23,7 +23,7 @@ export function LoginForm({ onEnter }: LoginFormProps) {
       <ControlledPasswordField
         name="password"
         fullWidth
-        label={t("password")}
+        label={t("login.password")}
         type="password"
         onKeyDown={(e) => {
           if (e.key === "Enter") onEnter?.();

--- a/frontend/src/hooks/auth/useChangePasswordMutation.ts
+++ b/frontend/src/hooks/auth/useChangePasswordMutation.ts
@@ -1,0 +1,33 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+import type { AuthUser } from "../../types/authUser";
+import type { AxiosError } from "axios";
+import { changePassword } from "../../api/auth";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../providers/useAuth";
+import type { ChangePasswordFormValues } from "../../types/changePasswordForm";
+
+export default function useChangePasswordMutation(
+  options?: UseMutationOptions<
+    AuthUser,
+    AxiosError,
+    Omit<ChangePasswordFormValues, "confirmNewPassword">
+  >,
+) {
+  const navigate = useNavigate();
+  const { setUser } = useAuth();
+
+  return useMutation<
+    AuthUser,
+    AxiosError,
+    Omit<ChangePasswordFormValues, "confirmNewPassword">
+  >({
+    ...options,
+    mutationFn: ({ currentPassword, newPassword }) =>
+      changePassword(currentPassword, newPassword),
+    onSuccess: (user, ...other) => {
+      setUser(user);
+      navigate(-1);
+      options?.onSuccess?.(user, ...other);
+    },
+  });
+}

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -6,5 +6,8 @@
     "submit": "Sign in",
     "error": "Invalid email or password",
     "demoCredentials": "Demo credentials are pre-filled. Just click Sign in."
-  }
+  },
+  "currentPassword": "Current password",
+  "newPassword": "New password",
+  "confirmNewPassword": "Confirm new password"
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -16,5 +16,7 @@
   "delete": "Delete",
   "dialogDeleteText": "Are you sure you want to delete this item? This action cannot be undone.",
   "changePassword": "Change password",
-  "logout": "Logout"
+  "logout": "Logout",
+  "settings": "Settings",
+  "submit": "Submit"
 }

--- a/frontend/src/i18n/locales/en/user.json
+++ b/frontend/src/i18n/locales/en/user.json
@@ -5,7 +5,6 @@
   "detail": "Detail",
   "create": "Create",
   "edit": "Edit",
-  "submit": "Submit",
   "name": "Name",
   "email": "Email",
   "fullName": "Full name",

--- a/frontend/src/i18n/locales/it/auth.json
+++ b/frontend/src/i18n/locales/it/auth.json
@@ -6,5 +6,8 @@
     "submit": "Accedi",
     "error": "Email o password non validi",
     "demoCredentials": "Le credenziali demo sono già inserite. Clicca su Accedi."
-  }
+  },
+  "currentPassword": "Password corrente",
+  "newPassword": "Nuova password",
+  "confirmNewPassword": "Conferma nuova password"
 }

--- a/frontend/src/i18n/locales/it/common.json
+++ b/frontend/src/i18n/locales/it/common.json
@@ -16,5 +16,7 @@
   "delete": "Elimina",
   "dialogDeleteText": "Sei sicuro di voler eliminare questo elemento? Questa azione non può essere annullata.",
   "changePassword": "Modifica password",
-  "logout": "Esci"
+  "logout": "Esci",
+  "settings": "Impostazioni",
+  "submit": "Salva"
 }

--- a/frontend/src/i18n/locales/it/user.json
+++ b/frontend/src/i18n/locales/it/user.json
@@ -5,7 +5,6 @@
   "detail": "Dettaglio",
   "create": "Crea",
   "edit": "Modifica",
-  "submit": "Salva",
   "name": "Nome",
   "email": "Email",
   "fullName": "Nome completo",

--- a/frontend/src/mocks/handlers/auth.handlers.ts
+++ b/frontend/src/mocks/handlers/auth.handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse, delay } from "msw";
 import { mockAdminUser } from "../data/auth.data";
+import type { ChangePasswordFormValues } from "../../types/changePasswordForm";
 
 export const authHandlers = [
   http.post<never, { email: string; password: string }>(
@@ -24,4 +25,22 @@ export const authHandlers = [
     await delay(300);
     return HttpResponse.json({ success: true });
   }),
+
+  http.post<never, Omit<ChangePasswordFormValues, "confirmNewPassword">>(
+    "/api/auth/change-password",
+    async ({ request }) => {
+      await delay(500);
+      const { currentPassword } = await request.json();
+      if (currentPassword !== "admin123")
+        return HttpResponse.json(
+          {
+            message: "Invalid credentials",
+            error: "Unauthorized",
+            statusCode: 401,
+          },
+          { status: 401 },
+        );
+      return HttpResponse.json({ user: mockAdminUser });
+    },
+  ),
 ];

--- a/frontend/src/pages/auth/ChangePasswordPage.tsx
+++ b/frontend/src/pages/auth/ChangePasswordPage.tsx
@@ -1,60 +1,50 @@
 import { useTranslation } from "react-i18next";
 import { Alert, Button, Container, Paper, Snackbar } from "@mui/material";
 import { FormProvider } from "react-hook-form";
-import {
-  userCreateFormSchema,
-  type UserCreateFormValues,
-} from "../../types/userForm";
 import useCustomForm from "../../hooks/useCustomForm";
-import useUserCreateMutation from "../../hooks/users/useUserCreateMutation";
-import { UserCreateForm } from "../../forms/users/UserCreateForm";
-import { useNavigate } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 import PageHeader from "../../components/PageHeader";
 import { omit } from "lodash";
 import { useState } from "react";
+import {
+  changePasswordFormSchema,
+  type ChangePasswordFormValues,
+} from "../../types/changePasswordForm";
+import useChangePasswordMutation from "../../hooks/auth/useChangePasswordMutation";
+import { ChangePasswordForm } from "../../forms/auth/ChangePasswordForm";
 
-export default function UserCreatePage() {
-  const { t } = useTranslation("user");
-  const queryClient = useQueryClient();
-  const navigate = useNavigate();
+export default function ChangePasswordPage() {
+  const { t } = useTranslation("auth");
 
   const [openErrorSnackbar, setOpenErrorSnackbar] = useState(false);
 
-  const userCreateForm = useCustomForm<UserCreateFormValues>({
-    schema: userCreateFormSchema,
+  const changePasswordForm = useCustomForm<ChangePasswordFormValues>({
+    schema: changePasswordFormSchema,
     defaultValues: {
-      email: "",
-      fullName: "",
-      password: "",
-      confirmPassword: "",
-      role: "dev",
+      currentPassword: "",
+      newPassword: "",
+      confirmNewPassword: "",
     },
   });
 
-  const userCreateMutation = useUserCreateMutation({
-    onSuccess: (user) => {
-      queryClient.setQueryData(["users", user.id], user);
-      navigate(`/user/${user.id}`, { replace: true });
-    },
+  const changePasswordMutation = useChangePasswordMutation({
     onError: () => {
       setOpenErrorSnackbar(true);
     },
   });
 
-  const handleSubmit = userCreateForm.handleSubmit((data) =>
-    userCreateMutation.mutate(omit(data, "confirmPassword")),
+  const handleSubmit = changePasswordForm.handleSubmit((data) =>
+    changePasswordMutation.mutate(omit(data, "confirmNewPassword")),
   );
 
   return (
     <>
-      <PageHeader title={t("users")} subtitle={t("create")} />
-      <Container maxWidth="sm">
+      <PageHeader title={t("changePassword", { ns: "common" })} />
+      <Container maxWidth="xs">
         <Paper elevation={3} sx={{ p: 4 }}>
-          <FormProvider {...userCreateForm}>
-            <UserCreateForm
+          <FormProvider {...changePasswordForm}>
+            <ChangePasswordForm
               onEnter={() => {
-                if (userCreateForm.formState.isValid) handleSubmit();
+                if (changePasswordForm.formState.isValid) handleSubmit();
               }}
             />
           </FormProvider>
@@ -64,10 +54,11 @@ export default function UserCreatePage() {
             variant="contained"
             size="large"
             disabled={
-              !userCreateForm.formState.isValid || userCreateMutation.isPending
+              !changePasswordForm.formState.isValid ||
+              changePasswordMutation.isPending
             }
             onClick={handleSubmit}
-            loading={userCreateMutation.isPending}
+            loading={changePasswordMutation.isPending}
             sx={{ mt: 2 }}
           >
             {t("submit", { ns: "common" })}

--- a/frontend/src/pages/auth/LoginPage.test.tsx
+++ b/frontend/src/pages/auth/LoginPage.test.tsx
@@ -23,7 +23,7 @@ vi.mock("react-router-dom", async (importOriginal) => ({
 }));
 
 const mockSetUser = vi.fn();
-vi.mock("../providers/useAuth", () => ({
+vi.mock("../../providers/useAuth", () => ({
   useAuth: () => ({ setUser: mockSetUser }),
 }));
 

--- a/frontend/src/pages/auth/LoginPage.test.tsx
+++ b/frontend/src/pages/auth/LoginPage.test.tsx
@@ -234,7 +234,7 @@ describe("LoginPage", () => {
 
       // force re-import with new env variable
       vi.resetModules();
-      const { default: LoginPage } = await import("../pages/LoginPage");
+      const { default: LoginPage } = await import("./LoginPage");
 
       await act(async () => {
         render(

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -8,13 +8,13 @@ import {
   Paper,
 } from "@mui/material";
 import { FormProvider } from "react-hook-form";
-import { LoginForm } from "../forms/LoginForm";
+import { LoginForm } from "../../forms/auth/LoginForm";
 
 const isDemoMode = import.meta.env.VITE_DEMO_MODE === "true";
 
-import useCustomForm from "../hooks/useCustomForm";
-import { loginFormSchema, type LoginFormValues } from "../types/loginForm";
-import useLoginMutation from "../hooks/auth/useLoginMutation";
+import useCustomForm from "../../hooks/useCustomForm";
+import { loginFormSchema, type LoginFormValues } from "../../types/loginForm";
+import useLoginMutation from "../../hooks/auth/useLoginMutation";
 
 export default function LoginPage() {
   const { t } = useTranslation("auth");

--- a/frontend/src/pages/users/UserCreatePage.tsx
+++ b/frontend/src/pages/users/UserCreatePage.tsx
@@ -85,7 +85,7 @@ export default function UserCreatePage() {
           onClose={() => {
             setOpenErrorSnackbar(false);
           }}
-          severity="success"
+          severity="error"
           variant="filled"
           sx={{ width: "100%" }}
         >

--- a/frontend/src/pages/users/UserEditPage.tsx
+++ b/frontend/src/pages/users/UserEditPage.tsx
@@ -69,7 +69,7 @@ export default function UserEditPage() {
             loading={userEditMutation.isPending}
             sx={{ mt: 2 }}
           >
-            {t("submit")}
+            {t("submit", { ns: "common" })}
           </Button>
         </Paper>
       </Container>

--- a/frontend/src/router/AppRoutes.tsx
+++ b/frontend/src/router/AppRoutes.tsx
@@ -14,7 +14,7 @@ const lazyWithLoader = (
   );
 };
 
-const LoginPage = lazyWithLoader(() => import("../pages/LoginPage"));
+const LoginPage = lazyWithLoader(() => import("../pages/auth/LoginPage"));
 const GenerateTicketPage = lazyWithLoader(
   () => import("../pages/GenerateTicketPage"),
 );
@@ -31,6 +31,9 @@ const UserEditPage = lazyWithLoader(
 const UserCreatePage = lazyWithLoader(
   () => import("../pages/users/UserCreatePage"),
 );
+const ChangePasswordPage = lazyWithLoader(
+  () => import("../pages/auth/ChangePasswordPage"),
+);
 
 export default function AppRoutes() {
   return (
@@ -43,6 +46,7 @@ export default function AppRoutes() {
         <Route path="/user/create" element={<UserCreatePage />} />
         <Route path="/user/:id" element={<UserDetailPage />} />
         <Route path="/user/:id/edit" element={<UserEditPage />} />
+        <Route path="/change-password" element={<ChangePasswordPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/frontend/src/types/changePasswordForm.ts
+++ b/frontend/src/types/changePasswordForm.ts
@@ -1,0 +1,15 @@
+import z from "zod";
+import i18n from "../i18n";
+
+export const changePasswordFormSchema = z
+  .object({
+    currentPassword: z.string().min(1),
+    newPassword: z.string().min(6),
+    confirmNewPassword: z.string(),
+  })
+  .refine((v) => v.newPassword === v.confirmNewPassword, {
+    path: ["confirmNewPassword"],
+    error: i18n.t("passwordsDontMatch", { ns: "errors", lng: i18n.language }),
+  });
+
+export type ChangePasswordFormValues = z.infer<typeof changePasswordFormSchema>;


### PR DESCRIPTION
## What
Add change password

## Changes
### Backend
- Create change password endpoint
- Revoke refresh tokens on success

### Frontend
- Add change password form
- Add navigation to change password page on settings menu item

## Notes
- Hide settings when user is not logged
- Fix user error snackbar severity

## Test
Add test for change password service

Closes #47 