### PR TITLE
57 feat remove revoked refresh tokens from db

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -99,15 +99,9 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
   ) {
     const currentUser = req.user as JwtUser;
-    const currentRawRefreshToken = (req.cookies as Record<string, string>)
-      ?.refresh_token;
 
     const { accessToken, refreshToken, user } =
-      await this.authService.changePassword(
-        currentUser.id,
-        dto,
-        currentRawRefreshToken,
-      );
+      await this.authService.changePassword(currentUser.id, dto);
 
     this.setTokenCookies(res, accessToken, refreshToken);
     return { user };

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -40,7 +40,7 @@ export class AuthController {
     res.cookie('refresh_token', refreshToken, {
       ...COOKIE_BASE,
       maxAge: 7 * 24 * 60 * 60 * 1000,
-      path: '/api/auth/refresh',
+      path: '/api/auth',
     });
   }
 
@@ -82,7 +82,7 @@ export class AuthController {
     res.clearCookie('access_token', COOKIE_BASE);
     res.clearCookie('refresh_token', {
       ...COOKIE_BASE,
-      path: 'api/auth/refresh',
+      path: '/api/auth',
     });
   }
 

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -3,16 +3,19 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { RefreshToken } from './refresh-token.entity';
+import { TokenCleanupService } from './token-cleanup.service';
 import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
     PassportModule,
     UsersModule,
+    ScheduleModule.forRoot(),
     TypeOrmModule.forFeature([RefreshToken]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
@@ -24,6 +27,6 @@ import { UsersModule } from '../users/users.module';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, TokenCleanupService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
 import { UnauthorizedException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Not } from 'typeorm';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { Role, User } from '../users/user.entity';
@@ -31,7 +30,6 @@ const mockUser: User = {
 const mockStoredToken: RefreshToken = {
   id: 'uuid-456',
   tokenHash: 'hashed',
-  revoked: false,
   expiresAt: new Date(Date.now() + 1000 * 60 * 60),
   user: mockUser,
   userId: mockUser.id,
@@ -50,11 +48,21 @@ const mockJwtService = {
   sign: jest.fn().mockReturnValue('mock-jwt-token'),
 };
 
+// QueryBuilder mock — models the fluent chain used in the atomic DELETE
+const mockQbExecute = jest.fn();
+const mockQueryBuilder = {
+  delete: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  returning: jest.fn().mockReturnThis(),
+  execute: mockQbExecute,
+};
+
 const mockRefreshTokenRepo = {
   findOne: jest.fn(),
   save: jest.fn(),
   create: jest.fn(),
-  update: jest.fn(),
+  delete: jest.fn(),
+  createQueryBuilder: jest.fn(() => mockQueryBuilder),
 };
 
 // ─── Module factory ──────────────────────────────────────────────────────────
@@ -79,12 +87,6 @@ const rawLogoutToken = 'some-raw-token';
 const expectedLogoutHash = crypto
   .createHash('sha256')
   .update(rawLogoutToken)
-  .digest('hex');
-
-const rawChangePasswordToken = 'current-session-token';
-const expectedChangePasswordHash = crypto
-  .createHash('sha256')
-  .update(rawChangePasswordToken)
   .digest('hex');
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -193,6 +195,25 @@ describe('AuthService', () => {
 
   describe('refresh', () => {
     const rawToken = 'valid-raw-token';
+    const expectedHash = crypto
+      .createHash('sha256')
+      .update(rawToken)
+      .digest('hex');
+
+    // Helper: configure the atomic DELETE queryBuilder to simulate a
+    // successful token consumption (affected = 1, raw returns the userId row).
+    function mockAtomicDeleteSuccess() {
+      mockQbExecute.mockResolvedValue({
+        affected: 1,
+        raw: [{ userId: mockUser.id }],
+      });
+    }
+
+    // Helper: simulate the token not being found / already consumed / expired
+    // (the WHERE clause matched nothing → affected = 0).
+    function mockAtomicDeleteMiss() {
+      mockQbExecute.mockResolvedValue({ affected: 0, raw: [] });
+    }
 
     beforeEach(() => {
       mockRefreshTokenRepo.create.mockImplementation(
@@ -202,7 +223,8 @@ describe('AuthService', () => {
     });
 
     it('should issue new tokens on a valid refresh token', async () => {
-      mockRefreshTokenRepo.findOne.mockResolvedValue(mockStoredToken);
+      mockAtomicDeleteSuccess();
+      mockUsersService.findOneBy.mockResolvedValue(mockUser);
 
       const result = await service.refresh(rawToken);
 
@@ -215,29 +237,32 @@ describe('AuthService', () => {
       });
     });
 
-    it('should revoke the old token before issuing a new one (rotation)', async () => {
-      mockRefreshTokenRepo.findOne.mockResolvedValue({ ...mockStoredToken });
+    it('should atomically delete the old token during rotation', async () => {
+      mockAtomicDeleteSuccess();
+      mockUsersService.findOneBy.mockResolvedValue(mockUser);
 
       await service.refresh(rawToken);
 
-      expect(mockRefreshTokenRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({ revoked: true }),
+      // The WHERE clause must include the hashed token and the expiry guard
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        'tokenHash = :hash AND expiresAt > :now',
+        expect.objectContaining({ hash: expectedHash }),
       );
+      expect(mockQbExecute).toHaveBeenCalledTimes(1);
     });
 
-    it('should throw when token is not found or already revoked', async () => {
-      mockRefreshTokenRepo.findOne.mockResolvedValue(null);
+    it('should throw when the token is not found or already consumed (affected = 0)', async () => {
+      mockAtomicDeleteMiss();
 
       await expect(service.refresh(rawToken)).rejects.toThrow(
         UnauthorizedException,
       );
     });
 
-    it('should throw when token is expired', async () => {
-      mockRefreshTokenRepo.findOne.mockResolvedValue({
-        ...mockStoredToken,
-        expiresAt: new Date(Date.now() - 1000),
-      });
+    it('should throw when token is expired (filtered out by the WHERE clause)', async () => {
+      // An expired token is excluded by the `expiresAt > :now` predicate,
+      // so the DELETE reports affected = 0 — same path as "not found".
+      mockAtomicDeleteMiss();
 
       await expect(service.refresh(rawToken)).rejects.toThrow(
         UnauthorizedException,
@@ -245,40 +270,47 @@ describe('AuthService', () => {
     });
 
     it('should throw when the associated user is not active', async () => {
-      mockRefreshTokenRepo.findOne.mockResolvedValue({
-        ...mockStoredToken,
-        user: { ...mockUser, isActive: false },
+      mockAtomicDeleteSuccess();
+      mockUsersService.findOneBy.mockResolvedValue({
+        ...mockUser,
+        isActive: false,
       });
 
       await expect(service.refresh(rawToken)).rejects.toThrow(
         UnauthorizedException,
       );
     });
+
+    it('should not call findOneBy when the atomic delete reports no affected rows', async () => {
+      mockAtomicDeleteMiss();
+
+      await service.refresh(rawToken).catch(() => {});
+
+      expect(mockUsersService.findOneBy).not.toHaveBeenCalled();
+    });
   });
 
   // ── logout ─────────────────────────────────────────────────────────────────
 
   describe('logout', () => {
-    it('should revoke the refresh token by its hash', async () => {
-      mockRefreshTokenRepo.update.mockResolvedValue({});
+    it('should delete the refresh token by its hash', async () => {
+      mockRefreshTokenRepo.delete.mockResolvedValue({ affected: 1 });
 
       await service.logout(rawLogoutToken);
 
-      expect(mockRefreshTokenRepo.update).toHaveBeenCalledWith(
-        { tokenHash: expectedLogoutHash },
-        { revoked: true },
-      );
+      expect(mockRefreshTokenRepo.delete).toHaveBeenCalledWith({
+        tokenHash: expectedLogoutHash,
+      });
     });
 
-    it('should hash the raw token and never store it in plain text', async () => {
-      mockRefreshTokenRepo.update.mockResolvedValue({});
+    it('should hash the raw token and never use it in plain text', async () => {
+      mockRefreshTokenRepo.delete.mockResolvedValue({ affected: 1 });
 
       await service.logout(rawLogoutToken);
 
-      expect(mockRefreshTokenRepo.update).not.toHaveBeenCalledWith(
-        { tokenHash: rawLogoutToken },
-        expect.anything(),
-      );
+      expect(mockRefreshTokenRepo.delete).not.toHaveBeenCalledWith({
+        tokenHash: rawLogoutToken,
+      });
     });
   });
 
@@ -294,17 +326,17 @@ describe('AuthService', () => {
       mockRefreshTokenRepo.save.mockImplementation((data) =>
         Promise.resolve(data as RefreshToken),
       );
-      mockRefreshTokenRepo.update.mockResolvedValue({});
+      mockRefreshTokenRepo.delete.mockResolvedValue({ affected: 1 });
       mockUsersService.updatePassword.mockResolvedValue(undefined);
     });
 
     it('should return new tokens when credentials are valid', async () => {
       mockUsersService.findOneBy
-        .mockResolvedValueOnce(mockUser) // initial lookup
-        .mockResolvedValueOnce(mockUser); // post-update lookup
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      const result = await service.changePassword(mockUser.id, dto, undefined);
+      const result = await service.changePassword(mockUser.id, dto);
 
       expect(result.accessToken).toBe('mock-jwt-token');
       expect(result.user).toEqual({
@@ -321,7 +353,7 @@ describe('AuthService', () => {
         .mockResolvedValueOnce(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      const result = await service.changePassword(mockUser.id, dto, undefined);
+      const result = await service.changePassword(mockUser.id, dto);
 
       expect(result.refreshToken).toBeDefined();
       expect(typeof result.refreshToken).toBe('string');
@@ -330,9 +362,9 @@ describe('AuthService', () => {
     it('should throw UnauthorizedException when user is not found', async () => {
       mockUsersService.findOneBy.mockResolvedValue(null);
 
-      await expect(
-        service.changePassword(mockUser.id, dto, undefined),
-      ).rejects.toThrow(UnauthorizedException);
+      await expect(service.changePassword(mockUser.id, dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
 
     it('should throw UnauthorizedException when user is not active', async () => {
@@ -341,90 +373,43 @@ describe('AuthService', () => {
         isActive: false,
       });
 
-      await expect(
-        service.changePassword(mockUser.id, dto, undefined),
-      ).rejects.toThrow(UnauthorizedException);
+      await expect(service.changePassword(mockUser.id, dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
 
     it('should throw UnauthorizedException when the current password is wrong', async () => {
       mockUsersService.findOneBy.mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
-      await expect(
-        service.changePassword(mockUser.id, dto, undefined),
-      ).rejects.toThrow(UnauthorizedException);
+      await expect(service.changePassword(mockUser.id, dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
 
     it('should throw UnauthorizedException when updatedUser is not found after password update', async () => {
       mockUsersService.findOneBy
-        .mockResolvedValueOnce(mockUser) // initial lookup succeeds
-        .mockResolvedValueOnce(null); // post-update lookup returns nothing
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(null);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      await expect(
-        service.changePassword(mockUser.id, dto, undefined),
-      ).rejects.toThrow(UnauthorizedException);
+      await expect(service.changePassword(mockUser.id, dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
 
-    it('should revoke all user tokens when no currentRawRefreshToken is provided', async () => {
+    it('should delete all tokens for the user on password change', async () => {
       mockUsersService.findOneBy
         .mockResolvedValueOnce(mockUser)
         .mockResolvedValueOnce(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      await service.changePassword(mockUser.id, dto, undefined);
+      await service.changePassword(mockUser.id, dto);
 
-      expect(mockRefreshTokenRepo.update).toHaveBeenCalledWith(
-        { userId: mockUser.id, revoked: false },
-        { revoked: true },
-      );
-    });
-
-    it('should revoke all OTHER tokens (excluding the current session) when currentRawRefreshToken is provided', async () => {
-      mockUsersService.findOneBy
-        .mockResolvedValueOnce(mockUser)
-        .mockResolvedValueOnce(mockUser);
-      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
-
-      await service.changePassword(mockUser.id, dto, rawChangePasswordToken);
-
-      expect(mockRefreshTokenRepo.update).toHaveBeenCalledWith(
-        {
-          userId: mockUser.id,
-          revoked: false,
-          tokenHash: Not(expectedChangePasswordHash),
-        },
-        { revoked: true },
-      );
-    });
-
-    it('should also revoke the current session token after revoking the others', async () => {
-      mockUsersService.findOneBy
-        .mockResolvedValueOnce(mockUser)
-        .mockResolvedValueOnce(mockUser);
-      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
-
-      await service.changePassword(mockUser.id, dto, rawChangePasswordToken);
-
-      expect(mockRefreshTokenRepo.update).toHaveBeenCalledWith(
-        { tokenHash: expectedChangePasswordHash },
-        { revoked: true },
-      );
-    });
-
-    it('should hash the current session token and never use it in plain text', async () => {
-      mockUsersService.findOneBy
-        .mockResolvedValueOnce(mockUser)
-        .mockResolvedValueOnce(mockUser);
-      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
-
-      await service.changePassword(mockUser.id, dto, rawChangePasswordToken);
-
-      const allCalls = mockRefreshTokenRepo.update.mock.calls;
-      const usedRawToken = allCalls.some((args) =>
-        JSON.stringify(args).includes(rawChangePasswordToken),
-      );
-      expect(usedRawToken).toBe(false);
+      expect(mockRefreshTokenRepo.delete).toHaveBeenCalledTimes(1);
+      expect(mockRefreshTokenRepo.delete).toHaveBeenCalledWith({
+        userId: mockUser.id,
+      });
     });
 
     it('should call updatePassword with the correct userId and new password', async () => {
@@ -433,7 +418,7 @@ describe('AuthService', () => {
         .mockResolvedValueOnce(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      await service.changePassword(mockUser.id, dto, undefined);
+      await service.changePassword(mockUser.id, dto);
 
       expect(mockUsersService.updatePassword).toHaveBeenCalledWith(
         mockUser.id,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Not, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { UsersService } from '../users/users.service';
 import { RefreshToken } from './refresh-token.entity';
 import { LoginDto } from './dto/login.dto';
@@ -50,7 +50,7 @@ export class AuthService {
   async login(dto: LoginDto): Promise<AuthTokens> {
     const user = await this.usersService.findByEmail(dto.email);
 
-    // Always execute bcrypt.compare to avoid timing attack
+    // Always execute bcrypt.compare to avoid timing attacks
     const hashToCheck = user?.passwordHash ?? DUMMY_HASH;
     const passwordMatch = await bcrypt.compare(dto.password, hashToCheck);
 
@@ -63,39 +63,42 @@ export class AuthService {
 
   async refresh(rawRefreshToken: string): Promise<AuthTokens> {
     const hash = this.hashToken(rawRefreshToken);
+    const now = new Date();
 
-    const stored = await this.refreshTokenRepo.findOne({
-      where: { tokenHash: hash, revoked: false },
-      relations: ['user'],
-    });
+    const deleteResult = await this.refreshTokenRepo
+      .createQueryBuilder()
+      .delete()
+      .where('tokenHash = :hash AND expiresAt > :now', { hash, now })
+      .returning(['userId'])
+      .execute();
 
-    // Token not found, expired or revoked
-    if (!stored || stored.expiresAt < new Date()) {
+    if (!deleteResult.affected) {
+      // Token not found, already consumed by a concurrent request, or expired
       throw new UnauthorizedException(
         ErrorCode.INVALID_OR_EXPIRED_REFRESH_TOKEN,
       );
     }
 
-    if (!stored.user.isActive) {
+    // Safe to cast: RETURNING guarantees the row existed
+    const { userId } = (deleteResult.raw as { userId: string }[])[0];
+
+    const user = await this.usersService.findOneBy({ id: userId });
+
+    if (!user || !user.isActive) {
       throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
     }
 
-    // Rotation: revoke old token, emit a new one
-    stored.revoked = true;
-    await this.refreshTokenRepo.save(stored);
-
-    return this.issueTokens(stored.user);
+    return this.issueTokens(user);
   }
 
   async logout(rawRefreshToken: string): Promise<void> {
     const hash = this.hashToken(rawRefreshToken);
-    await this.refreshTokenRepo.update({ tokenHash: hash }, { revoked: true });
+    await this.refreshTokenRepo.delete({ tokenHash: hash });
   }
 
   async changePassword(
     userId: string,
     dto: ChangePasswordDto,
-    currentRawRefreshToken: string | undefined,
   ): Promise<AuthTokens> {
     const user = await this.usersService.findOneBy({ id: userId });
 
@@ -112,23 +115,7 @@ export class AuthService {
     }
 
     await this.usersService.updatePassword(userId, dto.newPassword);
-
-    if (currentRawRefreshToken) {
-      const currentHash = this.hashToken(currentRawRefreshToken);
-      await this.refreshTokenRepo.update(
-        { userId, revoked: false, tokenHash: Not(currentHash) },
-        { revoked: true },
-      );
-      await this.refreshTokenRepo.update(
-        { tokenHash: currentHash },
-        { revoked: true },
-      );
-    } else {
-      await this.refreshTokenRepo.update(
-        { userId, revoked: false },
-        { revoked: true },
-      );
-    }
+    await this.refreshTokenRepo.delete({ userId });
 
     const updatedUser = await this.usersService.findOneBy({ id: userId });
     if (!updatedUser) {

--- a/backend/src/auth/refresh-token.entity.ts
+++ b/backend/src/auth/refresh-token.entity.ts
@@ -26,9 +26,6 @@ export class RefreshToken {
   @Column()
   expiresAt!: Date;
 
-  @Column({ default: false })
-  revoked!: boolean;
-
   @CreateDateColumn()
   createdAt!: Date;
 }

--- a/backend/src/auth/token-cleanup.service.ts
+++ b/backend/src/auth/token-cleanup.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import { RefreshToken } from './refresh-token.entity';
+
+@Injectable()
+export class TokenCleanupService {
+  private readonly logger = new Logger(TokenCleanupService.name);
+
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepo: Repository<RefreshToken>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async purgeExpiredTokens(): Promise<void> {
+    const now = new Date();
+
+    const result = await this.refreshTokenRepo.delete({
+      expiresAt: LessThan(now),
+    });
+
+    this.logger.log(
+      `Token cleanup: removed ${result.affected ?? 0} expired refresh token(s).`,
+    );
+  }
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import type { AuthUser } from "../types/authUser";
 import { api } from "./axios.instance";
 
@@ -6,25 +5,20 @@ export async function login(
   email: string,
   password: string,
 ): Promise<AuthUser> {
-  const response = await axios.post<{ user: AuthUser }>(
-    "/api/auth/login",
-    { email, password },
-    { withCredentials: true },
-  );
+  const response = await api.post<{ user: AuthUser }>("/auth/login", {
+    email,
+    password,
+  });
   return response.data.user;
 }
 
 export async function refreshToken(): Promise<AuthUser> {
-  const response = await axios.post<{ user: AuthUser }>(
-    "/api/auth/refresh",
-    {},
-    { withCredentials: true },
-  );
+  const response = await api.post<{ user: AuthUser }>("/auth/refresh", {});
   return response.data.user;
 }
 
 export async function logout(): Promise<void> {
-  await api.post("/auth/logout", {}, { withCredentials: true });
+  await api.post("/auth/logout");
 }
 
 export async function changePassword(

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -15,9 +15,12 @@ const isDemoMode = import.meta.env.VITE_DEMO_MODE === "true";
 import useCustomForm from "../../hooks/useCustomForm";
 import { loginFormSchema, type LoginFormValues } from "../../types/loginForm";
 import useLoginMutation from "../../hooks/auth/useLoginMutation";
+import { useAuth } from "../../providers/useAuth";
+import { Navigate } from "react-router-dom";
 
 export default function LoginPage() {
   const { t } = useTranslation("auth");
+  const { isAuthenticated } = useAuth();
 
   const loginForm = useCustomForm<LoginFormValues>({
     schema: loginFormSchema,
@@ -32,6 +35,8 @@ export default function LoginPage() {
   const handleLogin = loginForm.handleSubmit((data) =>
     loginMutation.mutate(data),
   );
+
+  if (isAuthenticated) return <Navigate to="/" />;
 
   return (
     <Container maxWidth="xs">

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -37,7 +37,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
       pendingQueue = [];
     }
 
-    const SKIP_REFRESH_URLS = ["/auth/refresh", "/auth/login"];
+    const SKIP_REFRESH_URLS = ["/auth/refresh", "/auth/login", "/auth/logout"];
 
     const interceptorId = api.interceptors.response.use(
       (response) => response,
@@ -47,7 +47,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
         if (
           error.response?.status !== 401 ||
           SKIP_REFRESH_URLS.some((url) => requestUrl.includes(url)) ||
-          isDemoMode
+          isDemoMode ||
+          error.config._retry // already retried once, don't loop
         ) {
           return Promise.reject(error);
         }
@@ -59,6 +60,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
         }
 
         isRefreshing = true;
+        error.config._retry = true;
 
         try {
           await refreshToken();
@@ -66,7 +68,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
           return api.request(error.config);
         } catch (refreshError) {
           flushQueue(refreshError);
-          logout();
+          await logout();
           return Promise.reject(refreshError);
         } finally {
           isRefreshing = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,6 +2103,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/schedule@npm:^6.1.3":
+  version: 6.1.3
+  resolution: "@nestjs/schedule@npm:6.1.3"
+  dependencies:
+    cron: "npm:4.4.0"
+  peerDependencies:
+    "@nestjs/common": ^10.0.0 || ^11.0.0
+    "@nestjs/core": ^10.0.0 || ^11.0.0
+  checksum: 10c0/de6da8d0246f486f7fdefaf6991fea18718f7a2d2eb698cf40094bfaa21e028107e37a27352af4571370c14cd757ca7402b5398af544438cc046d28575dee827
+  languageName: node
+  linkType: hard
+
 "@nestjs/schematics@npm:^11.0.0, @nestjs/schematics@npm:^11.0.1":
   version: 11.0.10
   resolution: "@nestjs/schematics@npm:11.0.10"
@@ -3135,6 +3147,13 @@ __metadata:
   version: 4.17.24
   resolution: "@types/lodash@npm:4.17.24"
   checksum: 10c0/b72f60d4daacdad1fa643edb3faba204c02a01eb1ac00a83ff73496a6d236fc55e459c06106e8ced42277dba932d087d8fc090f8de4ef590d3f91e6d6f7ce85a
+  languageName: node
+  linkType: hard
+
+"@types/luxon@npm:~3.7.0":
+  version: 3.7.1
+  resolution: "@types/luxon@npm:3.7.1"
+  checksum: 10c0/2db30c13b58adcd86daa447faa3ba59515fe907ead8ee3e6bb716d662812af0619d712f6c1eb190cdd7f9d2c00444c3ecd80af0f36e8143eb0c5e7339d6b2aca
   languageName: node
   linkType: hard
 
@@ -4379,6 +4398,7 @@ __metadata:
     "@nestjs/jwt": "npm:^11.0.2"
     "@nestjs/passport": "npm:^11.0.5"
     "@nestjs/platform-express": "npm:^11.0.1"
+    "@nestjs/schedule": "npm:^6.1.3"
     "@nestjs/schematics": "npm:^11.0.0"
     "@nestjs/swagger": "npm:^11.2.6"
     "@nestjs/testing": "npm:^11.0.1"
@@ -5248,6 +5268,16 @@ __metadata:
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
   checksum: 10c0/157cbc59b2430ae9a90034a5f3a1b398b6738bf510f713edc4d4e45e169bc514d3d99dd34d8d01ca7ae7830b5b8b537e46ae8f3c8f932371b0875c0151d7ec91
+  languageName: node
+  linkType: hard
+
+"cron@npm:4.4.0":
+  version: 4.4.0
+  resolution: "cron@npm:4.4.0"
+  dependencies:
+    "@types/luxon": "npm:~3.7.0"
+    luxon: "npm:~3.7.0"
+  checksum: 10c0/e3762fda4a9a2404ac2e54e1104a3c6c695747e14b2321bbc5531aa1192c75a319075695fcaf68b6927e0ffd877b5454f314c680f6586db1a78b2c25b76b8a32
   languageName: node
   linkType: hard
 
@@ -8219,6 +8249,13 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
+  languageName: node
+  linkType: hard
+
+"luxon@npm:~3.7.0":
+  version: 3.7.2
+  resolution: "luxon@npm:3.7.2"
+  checksum: 10c0/ed8f0f637826c08c343a29dd478b00628be93bba6f068417b1d8896b61cb61c6deacbe1df1e057dbd9298334044afa150f9aaabbeb3181418ac8520acfdc2ae2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What
Change refresh token handling: tokens are no more revoked but deleted

## Changes
### Backend
- Add change password endpoint
- Add CRON job to delete expired tokens every day
- Delete tokens when revoked

### Frontend
- Login page redirect to dashboard if already logged in

## Notes
Fix refresh token path

## Test
Add change password tests

Closes #57
